### PR TITLE
"use indexmap::indexmap" instead of "extern crate indexmap"

### DIFF
--- a/src/area_of_study/tests.rs
+++ b/src/area_of_study/tests.rs
@@ -1,6 +1,6 @@
-use crate::rules::{count_of, course, req_ref};
-
 use super::*;
+use crate::rules::{count_of, course, req_ref};
+use indexmap::indexmap;
 
 #[test]
 fn deserialize() {

--- a/src/filter/tests.rs
+++ b/src/filter/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::traits::print::Print;
+use indexmap::indexmap;
 
 #[test]
 fn serialize_simple() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
 #![warn(clippy::all)]
 #![allow(clippy::bool_comparison)]
 
-#[cfg(test)]
-#[macro_use]
-extern crate indexmap;
-
 mod action;
 pub mod area_of_study;
 mod audit;

--- a/src/limit/tests.rs
+++ b/src/limit/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use indexmap::indexmap;
 
 #[test]
 fn serialize_level100() {

--- a/src/requirement/tests.rs
+++ b/src/requirement/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::rules::{given, req_ref};
 use crate::{filter, rules};
+use indexmap::indexmap;
 
 #[test]
 fn serialize() {

--- a/src/rules/given/tests.rs
+++ b/src/rules/given/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::traits::print::Print;
+use indexmap::indexmap;
 
 #[test]
 fn serialize_all_courses() {

--- a/src/rules/tests.rs
+++ b/src/rules/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::traits::print::Print;
+use indexmap::indexmap;
 
 #[test]
 fn deserialize_simple_course_in_array() {

--- a/src/save/tests.rs
+++ b/src/save/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::rules::{course, given};
 use crate::traits::print::Print;
+use indexmap::indexmap;
 
 #[test]
 fn deserialize() {


### PR DESCRIPTION
`use` the `indexmap!` macro where it's needed, instead of doing a global import. Part of Rust 2018.