### PR TITLE
Print limiters

### DIFF
--- a/src/rules/given/print.rs
+++ b/src/rules/given/print.rs
@@ -47,13 +47,23 @@ impl Rule {
 			Some(f) => format!(" {}", f.print()?),
 			None => "".to_string(),
 		};
+		let limits = if let Some(limits) = &self.limit {
+			let stringified = limits
+				.iter()
+				.map(|l| format!("at most {} {}", l.at_most, l.filter.print().unwrap()))
+				.collect::<Vec<_>>()
+				.oxford("and");
+			format!(" {}", stringified)
+		} else {
+			"".to_owned()
+		};
 
 		match &what {
 			What::Courses => {
 				let plur = self.action.should_pluralize();
 				let word = if plur { "courses" } else { "course" };
 
-				write!(&mut output, "take {} {}{}", action, word, filter)?;
+				write!(&mut output, "take {} {}{}{}", action, word, filter, limits)?;
 			}
 			What::DistinctCourses => {
 				let plur = self.action.should_pluralize();

--- a/tests/snapshots/2018-19/concentration/asian-studies.md
+++ b/tests/snapshots/2018-19/concentration/asian-studies.md
@@ -4,7 +4,7 @@
 For this concentration, you must complete the “Electives” requirement.
 
 ## Electives
-For this requirement, you must take at least six courses with the “asian_elective” attribute.
+For this requirement, you must take at least six courses with the “asian_elective” attribute at most 4 at not St. Olaf College.
 
 # Custom Attributes
 

--- a/tests/snapshots/2018-19/concentration/nordic-studies.md
+++ b/tests/snapshots/2018-19/concentration/nordic-studies.md
@@ -15,7 +15,7 @@ For this requirement, you must take one of the following courses:
 ## Electives
 > Note: Up to three courses from study abroad programs such as DIS, HECUA: The New Norway, and university direct-enroll programs may be counted toward the Nordic studies concentration
 
-For this requirement, you must take at least five courses with the “nordic_elective” attribute.
+For this requirement, you must take at least five courses with the “nordic_elective” attribute at most 3 with the “nordic_focus_norway” attribute and at most 2 within the NORW department.
 
 # Custom Attributes
 

--- a/tests/snapshots/2018-19/major/asian-studies-no-language.md
+++ b/tests/snapshots/2018-19/major/asian-studies-no-language.md
@@ -8,7 +8,7 @@ For this requirement, you must take at least one course with the “asian_semina
 
 
 ## Electives
-For this requirement, you must take at least seven courses with the “asian_elective” attribute.
+For this requirement, you must take at least seven courses with the “asian_elective” attribute at most 2 at the 100 level, at most 4 with the “asian_region_china” attribute, at most 4 with the “asian_region_japan” attribute, and at most 5 at not St. Olaf College, at either the 200 or 300 level.
 
 # Custom Attributes
 

--- a/tests/snapshots/2018-19/major/asian-studies.md
+++ b/tests/snapshots/2018-19/major/asian-studies.md
@@ -12,7 +12,7 @@ For this requirement, you must take at least one course with the “asian_semina
 
 
 ## Electives
-For this requirement, you must take at least six courses with the “asian_elective” attribute.
+For this requirement, you must take at least six courses with the “asian_elective” attribute at most 2 at the 100 level, at most 4 with the “asian_region_china” attribute, at most 4 with the “asian_region_japan” attribute, and at most 4 at not St. Olaf College, at either the 200 or 300 level.
 
 # Custom Attributes
 

--- a/tests/snapshots/2018-19/major/chinese.md
+++ b/tests/snapshots/2018-19/major/chinese.md
@@ -47,7 +47,7 @@ For this section, you must do all of the following:
 For this requirement, you must take at least one course with the “china_focused_on_china” attribute.
 
 ### Comparative
-For this requirement, you must take at least one course with the “china_comparative_asia” attribute.
+For this requirement, you must take at least one course with the “china_comparative_asia” attribute at most 2 with the “china_asiancon” attribute and at most 1 with either the china_independent_study or china_seminar attribute.
 
 
 ## FLAC

--- a/tests/snapshots/2018-19/major/french.md
+++ b/tests/snapshots/2018-19/major/french.md
@@ -31,7 +31,7 @@ For this requirement, you must take two of the following courses:
 
 
 ## Electives
-For this requirement, you must take at least two courses with the “french_elective” attribute.
+For this requirement, you must take at least two courses with the “french_elective” attribute at most 1 outside of the FREN department.
 
 # Custom Attributes
 

--- a/tests/snapshots/2018-19/major/japanese.md
+++ b/tests/snapshots/2018-19/major/japanese.md
@@ -47,7 +47,7 @@ For this section, you must do all of the following:
 For this requirement, you must take at least one course with the “japan_focused_on_japan” attribute.
 
 ### Comparative
-For this requirement, you must take at least one course with the “japan_comparative_asia” attribute.
+For this requirement, you must take at least one course with the “japan_comparative_asia” attribute at most 2 with the “japan_asiancon” attribute and at most 1 with either the japan_independent_study or japan_seminar attribute.
 
 
 ## FLAC

--- a/tests/snapshots/2018-19/major/mathematics.md
+++ b/tests/snapshots/2018-19/major/mathematics.md
@@ -71,7 +71,7 @@ For this requirement, you must both take PHYS 375 and declare one “Physics” 
 
 
 ## Level III
-For this requirement, you must take at least two courses with the “math_level_3” attribute.
+For this requirement, you must take at least two courses with the “math_level_3” attribute at most 1 outside of the MATH department.
 
 
 ## Sequence

--- a/tests/snapshots/2018-19/major/music.md
+++ b/tests/snapshots/2018-19/major/music.md
@@ -37,7 +37,7 @@ For this requirement, you must take one of the following courses:
 
 
 ## Electives
-For this requirement, you must take at least four courses within the MUSIC department, at either the 200 or 300 level.
+For this requirement, you must take at least four courses within the MUSIC department, at either the 200 or 300 level at most 3 at the 200 level.
 
 
 ## Performance Studies

--- a/tests/snapshots/2018-19/major/psychology.md
+++ b/tests/snapshots/2018-19/major/psychology.md
@@ -34,7 +34,7 @@ For this requirement, you must take two of the following courses:
 
 
 ## Level III Capstone
-For this requirement, you must take at least two courses with the “psych_level_3” attribute.
+For this requirement, you must take at least two courses with the “psych_level_3” attribute at most 1 with either the PSYCH 396 or PSYCH 398 `course` attribute.
 
 
 ## General Education


### PR DESCRIPTION
very much a WIP

currently:

> For this requirement, you must take at least seven courses with the “asian_elective” attribute at most 2 at the 100 level, at most 4 with the “asian_region_china” attribute, at most 4 with the “asian_region_japan” attribute, and at most 5 at not St. Olaf College, at either the 200 or 300 level.

aiming for something closer to:

> For this requirement, you must take at least seven courses with the “asian_elective” attribute, subject to the following restrictions:
>
> - At most 2 may be at the 100 level
> - At most 4 may have the “asian_region_china” attribute
> - At most 4 may have the “asian_region_japan” attribute
> - At most 5 courses at either the 200 or 300 level may be taken away from St. Olaf College

oh, and `master` just doesn't print limiters at all.