### PR TITLE
Discover independent top-level requirements, and solve them independently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 # Ignore IntelliJ files
 /.idea/
 /.vscode/
+*.log

--- a/benchmarks/bench_disjoints.py
+++ b/benchmarks/bench_disjoints.py
@@ -1,0 +1,145 @@
+from itertools import combinations
+import random
+import pytest
+
+
+def find_entirely_disjoint_sets(*sets):
+    dis = set()
+    joint = set()
+
+    for a, b in combinations(sets, 2):
+        if a.isdisjoint(b):
+            dis.add(a)
+            dis.add(b)
+        else:
+            joint.add(a)
+            joint.add(b)
+
+        if a in joint:
+            dis.discard(a)
+        if b in joint:
+            dis.discard(b)
+
+    return dis, joint
+
+
+def disjoint_2(*sets):
+    joint = set()
+    disjoint = set()
+
+    for a, b in combinations(sets, 2):
+        if a.isdisjoint(b):
+            if a in joint:
+                disjoint.discard(a)
+            else:
+                disjoint.add(a)
+
+            if b in joint:
+                disjoint.discard(b)
+            else:
+                disjoint.add(b)
+        else:
+            joint.add(a)
+            joint.add(b)
+            disjoint.discard(a)
+            disjoint.discard(b)
+
+    return disjoint, joint
+
+
+def disjoint_3(*sets):
+    joint = set()
+    disjoint = set()
+
+    for a, b in combinations(sets, 2):
+        if a.isdisjoint(b):
+            disjoint.add(a)
+            disjoint.add(b)
+        else:
+            joint.add(a)
+            joint.add(b)
+
+    for s in joint:
+        disjoint.discard(s)
+
+    return disjoint, joint
+
+
+def disjoint_4(*sets):
+    joint = set()
+    disjoint = set()
+
+    for a, b in combinations(sets, 2):
+        if a.isdisjoint(b):
+            disjoint.update((a, b))
+        else:
+            joint.update((a, b))
+
+    for s in joint:
+        disjoint.discard(s)
+
+    return disjoint, joint
+
+
+def disjoint_5(*sets):
+    joint = set()
+    disjoint = set()
+
+    for a, b in combinations(sets, 2):
+        if a.isdisjoint(b):
+            disjoint.update((a, b))
+        else:
+            joint.update((a, b))
+
+    disjoint = disjoint.difference(joint)
+
+    return disjoint, joint
+
+
+def setup():
+    return tuple(
+        frozenset(
+            random.randrange(1, 501)
+            for n in range(random.randrange(0, 50))
+        )
+        for _ in range(random.randrange(1, 101))
+    )
+
+
+data = setup()
+
+
+def test_disjoint():
+    dis_1, joint_1 = find_entirely_disjoint_sets(*data)
+    dis_2, joint_2 = disjoint_2(*data)
+    dis_3, joint_3 = disjoint_3(*data)
+    dis_4, joint_4 = disjoint_4(*data)
+    dis_5, joint_5 = disjoint_5(*data)
+
+    assert dis_1 == dis_2 == dis_3 == dis_4 == dis_5
+    assert joint_1 == joint_2 == joint_3 == joint_4 == joint_5
+
+
+@pytest.mark.benchmark(group="disjoint")
+def test_disjoint_1(benchmark):
+    dis, joint = benchmark(find_entirely_disjoint_sets, *data)
+
+
+@pytest.mark.benchmark(group="disjoint")
+def test_disjoint_2(benchmark):
+    dis_2, joint_2 = benchmark(disjoint_2, *data)
+
+
+@pytest.mark.benchmark(group="disjoint")
+def test_disjoint_3(benchmark):
+    dis_3, joint_3 = benchmark(disjoint_3, *data)
+
+
+@pytest.mark.benchmark(group="disjoint")
+def test_disjoint_4(benchmark):
+    dis_4, joint_4 = benchmark(disjoint_4, *data)
+
+
+@pytest.mark.benchmark(group="disjoint")
+def test_disjoint_5(benchmark):
+    dis_5, joint_5 = benchmark(disjoint_5, *data)

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Optional, Sequence, Iterable, Any, TYPE_CHECKING
+from typing import Dict, List, Tuple, Optional, Sequence, Iterable, Any, Union, TYPE_CHECKING
 import logging
 import decimal
 
@@ -30,7 +30,7 @@ class AreaOfStudy(Base):
     degree: Optional[str]
 
     limit: LimitSet
-    result: Rule
+    result: Any  # Rule
     attributes: Dict[str, Dict[str, List[str]]]
     multicountable: List[List[SingleClause]]
     path: Tuple[str, ...]
@@ -43,7 +43,7 @@ class AreaOfStudy(Base):
             "catalog": self.catalog,
             "major": self.major,
             "degree": self.degree,
-            "result": self.result.to_dict() if self.result is not None else None,
+            "result": self.result.to_dict(),
             "gpa": str(self.gpa()),
         }
 
@@ -170,6 +170,7 @@ class AreaSolution(AreaOfStudy):
 @dataclass(frozen=True)
 class AreaResult(AreaOfStudy, Result):
     __slots__ = ('result', 'context')
+
     result: Result
     context: RequirementContext
 

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -25,7 +25,7 @@ class AreaOfStudy:
 
     limit: LimitSet
     result: Rule
-    attributes: Dict[str, List[str]]
+    attributes: Dict[str, Dict[str, List[str]]]
     multicountable: List[List[SingleClause]]
 
     @staticmethod

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Tuple, Optional, Sequence, Iterable, Any, TYPE_CH
 import logging
 import decimal
 
-from .base import Solution, Result, Base
+from .base import Solution, Result, Base, Rule
 from .clause import SingleClause
 from .constants import Constants
 from .context import RequirementContext
@@ -11,6 +11,8 @@ from .data import CourseInstance, AreaPointer, AreaType
 from .exception import RuleException
 from .limit import LimitSet
 from .load_rule import load_rule
+from .result.count import CountResult
+from .result.requirement import RequirementResult
 from .lib import grade_point_average
 
 if TYPE_CHECKING:
@@ -161,8 +163,175 @@ class AreaSolution(AreaOfStudy):
             context=ctx,
         )
 
-    def audit(self) -> 'AreaResult':
-        return AreaResult.from_solution(area=self, result=self.solution.audit(ctx=self.context), ctx=self.context)
+    def audit(self, other_areas: Sequence[AreaPointer] = tuple()) -> 'AreaResult':
+        result = self.solution.audit(ctx=self.context)
+
+        # Append the "common" major requirements, if we've audited a major.
+        common_req_results = None
+        if self.kind == 'major':
+            common_req_results = self.audit_common_major_requirements(result=result, other_areas=other_areas)
+
+            if not isinstance(result, CountResult):
+                raise TypeError()
+
+            result = attr.evolve(result, items=tuple([*result.items, common_req_results]))
+
+        return AreaResult.from_solution(area=self, result=result, ctx=self.context)
+
+    def audit_common_major_requirements(self, result: Result, other_areas: Sequence[AreaPointer] = tuple()) -> RequirementResult:
+        """
+        Of the credits counting toward the minimum requirements for a major, a
+        total of six (6.00) must be completed with a grade of C or higher.
+
+        Only one full-course equivalent (1.00-credit course) taken S/U may
+        count toward the minimum requirements for a major. Some departments
+        have more stringent regulations.
+
+        While the maximum course credits counting toward a major in any one
+        department may vary, 21 total credits must be completed outside of the
+        SIS "department" code of the major. The 21 total credits include
+        Education Department courses attending the major. In order for a
+        student to be certified in a second or third major, 21 credits also
+        must be taken outside of the SIS "department" code of each of those
+        majors as well. If a student has a double major, courses taken in one
+        major count toward the 21 credits outside of the other major. Credits
+        outside the major department or program include full- (1.00) credit
+        courses plus partial- (.25, .50, .75) credit courses. Students who
+        double-major in studio art and art history are required to complete at
+        least 18 full-course credits outside the SIS "ART" department
+        designation.
+
+        """
+
+        other_area_codes = set(p.code for p in other_areas)
+        if '140' in other_area_codes and '135' in other_area_codes:
+            credits_message = " Students who double-major in studio art and art history are required to complete at least 18 full-course credits outside the SIS 'ART' subject code."
+            credits_outside_major = 18
+        else:
+            credits_message = ""
+            credits_outside_major = 21
+
+        claimed = set(result.matched(ctx=self.context))
+        unclaimed = list(set(self.context.transcript()) - claimed)
+        unclaimed_context = RequirementContext().with_transcript(unclaimed)
+        claimed_context = RequirementContext().with_transcript(claimed)
+        c = Constants(matriculation_year=0)
+
+        c_or_better = load_rule(
+            data={"requirement": "Credits at a C or higher"},
+            children={
+                "Credits at a C or higher": {
+                    "audited_by": "registrar",
+                    "message": "Of the credits counting toward the minimum requirements for a major, a total of six (6.00) must be completed with a grade of C or higher.",
+                    "result": {
+                        "from": {"student": "courses"},
+                        "allow_claimed": True,
+                        "claim": False,
+                        "where": {"grade": {"$gte": "C"}},
+                        "assert": {"count(courses)": {"$gte": 6}},
+                    },
+                },
+            },
+            path=['$', '%Common Requirements', '.count', '[0]'],
+            c=c,
+        )
+
+        s_u_credits = load_rule(
+            data={"requirement": "Credits taken S/U"},
+            children={
+                "Credits taken S/U": {
+                    "audited_by": "registrar",
+                    "message": "Only one full-course equivalent (1.00-credit course) taken S/U may count toward the minimum requirements for a major.",
+                    "result": {
+                        "from": {"student": "courses"},
+                        "allow_claimed": True,
+                        "claim": False,
+                        "where": {
+                            "$and": [
+                                {"s/u": {"$eq": True}},
+                                {"credits": {"$eq": 1.00}},
+                            ],
+                        },
+                        "assert": {"count(courses)": {"$lte": 1}},
+                    },
+                },
+            },
+            path=['$', '%Common Requirements', '.count', '[1]'],
+            c=c,
+        )
+
+        outside_the_major = load_rule(
+            data={"requirement": "Credits outside the major"},
+            children={
+                "Credits outside the major": {
+                    "audited_by": "registrar",
+                    "message": f"21 total credits must be completed outside of the SIS 'subject' code of the major.{credits_message}",
+                    "result": {
+                        "from": {"student": "courses"},
+                        "allow_claimed": True,
+                        "claim": False,
+                        "assert": {"sum(credits)": {"$gte": credits_outside_major}},
+                    },
+                },
+            },
+            path=['$', '%Common Requirements', '.count', '[2]'],
+            c=c,
+        )
+
+        c_or_better__result = find_best_solution(rule=c_or_better, ctx=claimed_context)
+        if c_or_better__result is None:
+            raise TypeError('no solutions found for c_or_better rule')
+        claimed_context.reset_claims()
+
+        s_u_credits__result = find_best_solution(rule=s_u_credits, ctx=claimed_context)
+        if s_u_credits__result is None:
+            raise TypeError('no solutions found for s_u_credits__result rule')
+        claimed_context.reset_claims()
+
+        outside_the_major__result = find_best_solution(rule=outside_the_major, ctx=unclaimed_context)
+        if outside_the_major__result is None:
+            raise TypeError('no solutions found for outside_the_major__result rule')
+        unclaimed_context.reset_claims()
+
+        return RequirementResult(
+            name="Common Requirements",
+            message="The following requirements are common to all majors offered at St. Olaf College.",
+            path=('$', '%Common Requirements'),
+            audited_by=None,
+            is_contract=False,
+            overridden=False,
+            result=CountResult(
+                path=('$', '%Common Requirements', '.count'),
+                count=3,
+                at_most=False,
+                audit_clauses=tuple(),
+                audit_results=tuple(),
+                overridden=False,
+                items=tuple([
+                    c_or_better__result,
+                    s_u_credits__result,
+                    outside_the_major__result,
+                ]),
+            ),
+        )
+
+
+def find_best_solution(*, rule: Rule, ctx: RequirementContext) -> Optional[Result]:
+    result = None
+
+    for s in rule.solutions(ctx=ctx):
+        tmp_result = s.audit(ctx=ctx)
+
+        if result is None:
+            result = tmp_result
+
+        if result.rank() < tmp_result.rank():
+            result = tmp_result
+
+        if tmp_result.ok():
+            result = tmp_result
+
+    return result
 
 
 @attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Optional, Sequence, Iterable, Any, Union, TYPE_CHECKING
+from typing import Dict, List, Tuple, Optional, Sequence, Iterable, Any, TYPE_CHECKING
 import logging
 import decimal
 
-from .base import Rule, Solution, Result, Base
+from .base import Solution, Result, Base
 from .clause import SingleClause
 from .constants import Constants
 from .context import RequirementContext

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -174,7 +174,7 @@ class AreaSolution(AreaOfStudy):
             if not isinstance(result, CountResult):
                 raise TypeError()
 
-            result = attr.evolve(result, items=tuple([*result.items, common_req_results]))
+            result = attr.evolve(result, items=tuple([*result.items, common_req_results]), count=result.count + 1)
 
         return AreaResult.from_solution(area=self, result=result, ctx=self.context)
 

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -25,8 +25,8 @@ class AreaOfStudy:
 
     limit: LimitSet
     result: Rule
-    attributes: Dict
-    multicountable: List
+    attributes: Dict[str, List[str]]
+    multicountable: List[List[SingleClause]]
 
     @staticmethod
     def load(*, specification: Dict, c: Constants, other_areas: Sequence[AreaPointer] = tuple()) -> 'AreaOfStudy':
@@ -43,7 +43,7 @@ class AreaOfStudy:
         limit = LimitSet.load(data=specification.get("limit", None), c=c)
 
         attributes = specification.get("attributes", dict())
-        multicountable = []
+        multicountable: List[List[SingleClause]] = []
         for ruleset in attributes.get("multicountable", []):
             clauses = []
             for clause in ruleset:

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Optional, Sequence, Iterable, Any
+from typing import Dict, List, Tuple, Optional, Sequence, Iterable, Any, TYPE_CHECKING
 import logging
 import decimal
 
 from .base import Rule, Solution, Result, Base
 from .clause import SingleClause
-from .claim import ClaimAttempt
 from .constants import Constants
 from .context import RequirementContext
 from .data import CourseInstance, AreaPointer, AreaType
@@ -13,6 +12,9 @@ from .exception import RuleException
 from .limit import LimitSet
 from .load_rule import load_rule
 from .lib import grade_point_average
+
+if TYPE_CHECKING:
+    from .claim import ClaimAttempt  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Dict, List, Tuple, Optional, Sequence, Iterable, Any, TYPE_CHECKING
 import logging
 import decimal
@@ -19,10 +19,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class AreaOfStudy(Base):
     """The overall class for working with an area"""
-    __slots__ = ('name', 'kind', 'catalog', 'major', 'degree', 'limit', 'result', 'attributes', 'multicountable', 'path')
     name: str
     kind: str
     catalog: str
@@ -140,9 +139,8 @@ class AreaOfStudy(Base):
         return iterations
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class AreaSolution(AreaOfStudy):
-    __slots__ = ('solution', 'context')
     solution: Solution
     context: RequirementContext
 
@@ -167,10 +165,8 @@ class AreaSolution(AreaOfStudy):
         return AreaResult.from_solution(area=self, result=self.solution.audit(ctx=self.context), ctx=self.context)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class AreaResult(AreaOfStudy, Result):
-    __slots__ = ('result', 'context')
-
     result: Result
     context: RequirementContext
 

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -120,7 +120,7 @@ class AreaOfStudy(Base):
                 multicountable=self.multicountable,
             ).with_transcript(limited_transcript)
 
-            for sol in self.result.solutions(ctx=ctx):
+            for sol in self.result.solutions(ctx=ctx, depth=1):
                 ctx.reset_claims()
                 yield AreaSolution.from_area(solution=sol, area=self, ctx=ctx)
 

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -75,9 +75,9 @@ class AreaOfStudy:
 
     def solutions(
         self, *,
-        transcript: Tuple[CourseInstance, ...],
-        areas: Tuple[AreaPointer, ...],
-        exceptions: Tuple[RuleException, ...],
+        transcript: Sequence[CourseInstance],
+        areas: Sequence[AreaPointer],
+        exceptions: Sequence[RuleException],
     ) -> Iterable['AreaSolution']:
         logger.debug("evaluating area.result")
 
@@ -88,7 +88,11 @@ class AreaOfStudy:
 
             logger.debug("%s evaluating area.result with limited transcript", limited_transcript)
 
-            ctx = RequirementContext(areas=areas, exceptions=mapped_exceptions, multicountable=self.multicountable).with_transcript(limited_transcript)
+            ctx = RequirementContext(
+                areas=tuple(areas),
+                exceptions=mapped_exceptions,
+                multicountable=self.multicountable,
+            ).with_transcript(limited_transcript)
 
             for sol in self.result.solutions(ctx=ctx):
                 ctx.reset_claims()
@@ -100,7 +104,10 @@ class AreaOfStudy:
         iterations = 0
 
         for limited_transcript in self.limit.limited_transcripts(courses=transcript):
-            ctx = RequirementContext(areas=areas, multicountable=self.multicountable).with_transcript(limited_transcript)
+            ctx = RequirementContext(
+                areas=areas,
+                multicountable=self.multicountable,
+            ).with_transcript(limited_transcript)
 
             iterations += self.result.estimate(ctx=ctx)
 
@@ -112,6 +119,7 @@ class AreaSolution(AreaOfStudy):
     solution: Solution
     context: RequirementContext
 
+    @staticmethod
     def from_area(*, area: AreaOfStudy, solution: Solution, ctx: RequirementContext) -> 'AreaSolution':
         return AreaSolution(
             name=area.name,

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -1,4 +1,4 @@
-import dataclasses
+import attr
 from typing import List, Optional, Tuple, Sequence, Iterator, Union, cast
 from datetime import datetime
 import time
@@ -10,7 +10,7 @@ from .ms import pretty_ms
 from .data import CourseInstance, AreaPointer
 
 
-@dataclasses.dataclass
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class Arguments:
     area_files: List[str]
     student_files: List[str]
@@ -18,19 +18,19 @@ class Arguments:
     estimate_only: bool = False
 
 
-@dataclasses.dataclass
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class NoStudentsMsg:
     pass
 
 
-@dataclasses.dataclass
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class AuditStartMsg:
     stnum: str
     area_code: str
     area_catalog: str
 
 
-@dataclasses.dataclass
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class ResultMsg:
     result: AreaResult
     transcript: Tuple[CourseInstance, ...]
@@ -40,18 +40,18 @@ class ResultMsg:
     startup_time: float
 
 
-@dataclasses.dataclass
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class ExceptionMsg:
     ex: Exception
     tb: str
 
 
-@dataclasses.dataclass
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class NoAuditsCompletedMsg:
     pass
 
 
-@dataclasses.dataclass
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class ProgressMsg:
     count: int
     recent_iters: List[float]
@@ -59,7 +59,7 @@ class ProgressMsg:
     best_rank: int
 
 
-@dataclasses.dataclass
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class EstimateMsg:
     estimate: int
 

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -107,8 +107,8 @@ def audit(
     iter_start = time.perf_counter()
     startup_time = 0.00
 
-    estimate = area.estimate(transcript=this_transcript, areas=tuple(area_pointers))
-    yield EstimateMsg(estimate=estimate)
+    # estimate = area.estimate(transcript=this_transcript, areas=tuple(area_pointers))
+    # yield EstimateMsg(estimate=estimate)
 
     if estimate_only:
         return

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -88,8 +88,8 @@ def audit(
     _transcript = []
     attributes_to_attach: Dict[str, List[str]] = area.attributes.get("courses", {})
     for c in transcript:
-        if c.is_repeat:
-            continue
+        # We need to leave repeated courses in the transcript, because some majors (THEAT) require repeated courses
+        # for completion.
         attrs_by_course: Set[str] = set(attributes_to_attach.get(c.course(), []))
         attrs_by_shorthand: Set[str] = set(attributes_to_attach.get(c.course_shorthand(), []))
         attrs_by_term: Set[str] = set(attributes_to_attach.get(c.course_with_term(), []))

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -86,7 +86,7 @@ def audit(
     area.validate()
 
     _transcript = []
-    attributes_to_attach = area.attributes.get("courses", {})
+    attributes_to_attach: Dict[str, List[str]] = area.attributes.get("courses", {})
     for c in transcript:
         if c.is_repeat:
             continue

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List, Optional, Set, Dict, Tuple, Sequence, Iterator, Any, Union
+from typing import List, Optional, Set, Dict, Tuple, Sequence, Iterator, Any, Union, cast
 from datetime import datetime
 import time
 
@@ -121,7 +121,7 @@ def audit(
                 count=total_count,
                 recent_iters=iterations[-1_000:],
                 start_time=start_time,
-                best_rank=best_sol.rank(),
+                best_rank=cast(AreaResult, best_sol).rank(),
             )
 
         result = sol.audit()

--- a/degreepath/base/__init__.py
+++ b/degreepath/base/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-from .bases import Base, Rule, Result, Solution, ResultStatus
+from .bases import Base, Rule, Result, Solution, ResultStatus, sort_by_path
 from .course import BaseCourseRule
 from .count import BaseCountRule
 from .query import BaseQueryRule

--- a/degreepath/base/assertion.py
+++ b/degreepath/base/assertion.py
@@ -7,6 +7,7 @@ from .bases import Base
 
 @dataclass(frozen=True)
 class BaseAssertionRule(Base):
+    __slots__ = ('assertion', 'where', 'path')
     assertion: Clause
     where: Optional[Clause]
     path: Tuple[str, ...]

--- a/degreepath/base/assertion.py
+++ b/degreepath/base/assertion.py
@@ -21,3 +21,9 @@ class BaseAssertionRule(Base):
 
     def type(self) -> str:
         return "assertion"
+
+    def rank(self) -> int:
+        return self.assertion.rank()
+
+    def max_rank(self) -> int:
+        return self.assertion.max_rank()

--- a/degreepath/base/assertion.py
+++ b/degreepath/base/assertion.py
@@ -1,13 +1,12 @@
-from dataclasses import dataclass
+import attr
 from typing import Optional, Tuple, Dict, Any
 from ..clause import Clause
 
 from .bases import Base
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class BaseAssertionRule(Base):
-    __slots__ = ('assertion', 'where', 'path')
     assertion: Clause
     where: Optional[Clause]
     path: Tuple[str, ...]

--- a/degreepath/base/bases.py
+++ b/degreepath/base/bases.py
@@ -17,6 +17,7 @@ class ResultStatus(enum.Enum):
 
 
 class Base(abc.ABC):
+    __slots__ = ('path',)
     path: Tuple[str, ...]
 
     def __lt__(self, other: 'Base') -> bool:
@@ -69,11 +70,15 @@ class Base(abc.ABC):
 
 
 class Result(Base):
+    __slots__ = ()
+
     def state(self) -> str:
         return "result"
 
 
 class Solution(Base):
+    __slots__ = ()
+
     def state(self) -> str:
         return "solution"
 
@@ -83,6 +88,8 @@ class Solution(Base):
 
 
 class Rule(Base):
+    __slots__ = ()
+
     def state(self) -> str:
         return "rule"
 

--- a/degreepath/base/bases.py
+++ b/degreepath/base/bases.py
@@ -1,11 +1,12 @@
 import abc
-from typing import Iterator, Dict, Any, List, Tuple, TYPE_CHECKING
+from typing import Iterator, Dict, Any, List, Tuple, Collection, TYPE_CHECKING
 import enum
 
 if TYPE_CHECKING:
     from ..context import RequirementContext
     from ..claim import ClaimAttempt  # noqa: F401
     from ..data import CourseInstance  # noqa: F401
+    from ..data import Clausable  # noqa: F401
 
 
 @enum.unique
@@ -107,6 +108,10 @@ class Rule(Base):
     @abc.abstractmethod
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
         raise NotImplementedError(f'must define a has_potential() method')
+
+    @abc.abstractmethod
+    def all_matches(self, *, ctx: 'RequirementContext') -> Collection['Clausable']:
+        raise NotImplementedError(f'must define an all_matches() method')
 
 
 def compare_path_tuples_a_lt_b(a: Tuple[str, ...], b: Tuple[str, ...]) -> bool:

--- a/degreepath/base/bases.py
+++ b/degreepath/base/bases.py
@@ -32,7 +32,6 @@ class Base(abc.ABC):
             "ok": self.ok(),
             "rank": self.rank(),
             "max_rank": self.max_rank(),
-            "claims": [c.to_dict() for c in self.claims()],
             "overridden": self.was_overridden(),
         }
 

--- a/degreepath/base/bases.py
+++ b/degreepath/base/bases.py
@@ -132,6 +132,8 @@ def compare_path_tuples_a_lt_b(a: Tuple[str, ...], b: Tuple[str, ...]) -> bool:
     if b_len < a_len:
         return False
 
+    _1: Any
+    _2: Any
     for _1, _2 in zip(a, b):
         # convert indices to integers
         if _1 and _1[0] == '[':
@@ -143,7 +145,10 @@ def compare_path_tuples_a_lt_b(a: Tuple[str, ...], b: Tuple[str, ...]) -> bool:
         if type(_1) == type(_2):
             if _1 == _2:
                 continue
-            return _1 < _2
+            if _1 < _2:
+                return True
+            else:
+                return False
         elif type(_1) == int:
             return True
         else:

--- a/degreepath/base/bases.py
+++ b/degreepath/base/bases.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Iterator, Dict, Any, List, Tuple, Collection, TYPE_CHECKING
+from typing import Iterator, Dict, Any, List, Tuple, Collection, Optional, TYPE_CHECKING
 import enum
 
 if TYPE_CHECKING:
@@ -98,7 +98,7 @@ class Rule(Base):
         raise NotImplementedError(f'must define a validate() method')
 
     @abc.abstractmethod
-    def solutions(self, *, ctx: 'RequirementContext') -> Iterator[Solution]:
+    def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[Solution]:
         raise NotImplementedError(f'must define a solutions() method')
 
     @abc.abstractmethod

--- a/degreepath/base/count.py
+++ b/degreepath/base/count.py
@@ -32,12 +32,14 @@ class BaseCountRule(Base):
         return "count"
 
     def rank(self) -> int:
-        return sum(r.rank() for r in self.items)
+        return sum(r.rank() for r in self.items) + sum(c.rank() for c in self.audit_clauses)
 
     def max_rank(self) -> int:
-        ranks = (r.max_rank() for r in self.items)
+        audit_max_rank = sum(c.rank() for c in self.audit_clauses)
         if len(self.items) == 2 and self.count == 2:
-            return sum(sorted(ranks)[:2])
+            return sum(sorted(r.max_rank() for r in self.items)[:2]) + audit_max_rank
+
         if self.count == 1 and self.at_most:
-            return max(ranks)
-        return sum(ranks)
+            return max(r.max_rank() for r in self.items) + audit_max_rank
+
+        return sum(r.max_rank() for r in self.items) + audit_max_rank

--- a/degreepath/base/count.py
+++ b/degreepath/base/count.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class BaseCountRule(Base):
+    __slots__ = ('count', 'items', 'at_most', 'audit_clauses')
     count: int
     items: Tuple[Union[Rule, Solution, Result], ...]
     at_most: bool

--- a/degreepath/base/count.py
+++ b/degreepath/base/count.py
@@ -30,3 +30,14 @@ class BaseCountRule(Base):
 
     def type(self) -> str:
         return "count"
+
+    def rank(self) -> int:
+        return sum(r.rank() for r in self.items)
+
+    def max_rank(self) -> int:
+        ranks = (r.max_rank() for r in self.items)
+        if len(self.items) == 2 and self.count == 2:
+            return sum(sorted(ranks)[:2])
+        if self.count == 1 and self.at_most:
+            return max(ranks)
+        return sum(ranks)

--- a/degreepath/base/count.py
+++ b/degreepath/base/count.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Tuple, Union, Dict, Any, Sequence
 import logging
 
@@ -8,9 +8,8 @@ from .assertion import BaseAssertionRule
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class BaseCountRule(Base):
-    __slots__ = ('count', 'items', 'at_most', 'audit_clauses')
     count: int
     items: Tuple[Union[Rule, Solution, Result], ...]
     at_most: bool

--- a/degreepath/base/course.py
+++ b/degreepath/base/course.py
@@ -46,3 +46,9 @@ class BaseCourseRule(Base):
             return self.course in clause.expected
         else:
             return False
+
+    def rank(self) -> int:
+        return 1 if self.ok() else 0
+
+    def max_rank(self) -> int:
+        return 1

--- a/degreepath/base/course.py
+++ b/degreepath/base/course.py
@@ -25,6 +25,7 @@ class BaseCourseRule(Base):
             "hidden": self.hidden,
             "grade": str(self.grade) if self.grade is not None else None,
             "allow_claimed": self.allow_claimed,
+            "claims": [c.to_dict() for c in self.claims()],
         }
 
     def type(self) -> str:

--- a/degreepath/base/course.py
+++ b/degreepath/base/course.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class BaseCourseRule(Base):
+    __slots__ = ('course', 'hidden', 'grade', 'allow_claimed')
     course: str
     hidden: bool
     grade: Optional[Decimal]

--- a/degreepath/base/course.py
+++ b/degreepath/base/course.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Optional, Tuple, Dict, Any, TYPE_CHECKING
 from decimal import Decimal
 
@@ -9,9 +9,8 @@ if TYPE_CHECKING:
     from ..clause import SingleClause
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class BaseCourseRule(Base):
-    __slots__ = ('course', 'hidden', 'grade', 'allow_claimed')
     course: str
     hidden: bool
     grade: Optional[Decimal]

--- a/degreepath/base/query.py
+++ b/degreepath/base/query.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Optional, Tuple, Dict, Any
 import enum
 
@@ -26,9 +26,8 @@ class QuerySourceRepeatMode(enum.Enum):
     All = "all"
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class BaseQueryRule(Base):
-    __slots__ = ('source', 'source_type', 'source_repeats', 'assertions', 'limit', 'where', 'allow_claimed', 'attempt_claims')
     source: QuerySource
     source_type: QuerySourceType
     source_repeats: QuerySourceRepeatMode

--- a/degreepath/base/query.py
+++ b/degreepath/base/query.py
@@ -28,6 +28,7 @@ class QuerySourceRepeatMode(enum.Enum):
 
 @dataclass(frozen=True)
 class BaseQueryRule(Base):
+    __slots__ = ('source', 'source_type', 'source_repeats', 'assertions', 'limit', 'where', 'allow_claimed', 'attempt_claims')
     source: QuerySource
     source_type: QuerySourceType
     source_repeats: QuerySourceRepeatMode

--- a/degreepath/base/query.py
+++ b/degreepath/base/query.py
@@ -49,6 +49,7 @@ class BaseQueryRule(Base):
             "assertions": [a.to_dict() for a in self.assertions],
             "where": self.where.to_dict() if self.where else None,
             "allow_claimed": self.allow_claimed,
+            "claims": [c.to_dict() for c in self.claims()],
             "failures": [],
         }
 

--- a/degreepath/base/requirement.py
+++ b/degreepath/base/requirement.py
@@ -13,6 +13,7 @@ class AuditedBy(enum.Enum):
 
 @dataclass(frozen=True)
 class BaseRequirementRule(Base):
+    __slots__ = ('name', 'message', 'result', 'audited_by', 'is_contract')
     name: str
     message: Optional[str]
     result: Optional[Base]

--- a/degreepath/base/requirement.py
+++ b/degreepath/base/requirement.py
@@ -33,3 +33,10 @@ class BaseRequirementRule(Base):
 
     def type(self) -> str:
         return "requirement"
+
+    def rank(self) -> int:
+        boost = 1 if self.ok() else 0
+        return self.result.rank() + boost if self.result else 0
+
+    def max_rank(self) -> int:
+        return self.result.max_rank() + 1 if self.result else 0

--- a/degreepath/base/requirement.py
+++ b/degreepath/base/requirement.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Optional, Tuple, Dict, Any
 import enum
 
@@ -11,9 +11,8 @@ class AuditedBy(enum.Enum):
     Registrar = "registrar"
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class BaseRequirementRule(Base):
-    __slots__ = ('name', 'message', 'result', 'audited_by', 'is_contract')
     name: str
     message: Optional[str]
     result: Optional[Base]

--- a/degreepath/claim.py
+++ b/degreepath/claim.py
@@ -31,15 +31,17 @@ class Claim:
 @attr.s(frozen=True, cache_hash=True, auto_attribs=True, slots=True)
 class ClaimAttempt:
     claim: Claim
-    conflict_with: FrozenSet[Claim] = attr.ib(factory=frozenset)
+    conflict_with: FrozenSet[Claim]
+    did_fail: bool
 
     def failed(self) -> bool:
-        return len(self.conflict_with) > 0
+        return self.did_fail
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "claim": self.claim.to_dict(),
             "conflict_with": [c.to_dict() for c in self.conflict_with],
+            "failed": self.failed(),
         }
 
     def get_course(self, *, ctx: 'RequirementContext') -> Optional['CourseInstance']:

--- a/degreepath/claim.py
+++ b/degreepath/claim.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@attr.s(frozen=True, cache_hash=True, auto_attribs=True)
+@attr.s(frozen=True, cache_hash=True, auto_attribs=True, slots=True)
 class Claim:
     crsid: str
     clbid: str
@@ -28,7 +28,7 @@ class Claim:
         }
 
 
-@attr.s(frozen=True, cache_hash=True, auto_attribs=True)
+@attr.s(frozen=True, cache_hash=True, auto_attribs=True, slots=True)
 class ClaimAttempt:
     claim: Claim
     conflict_with: FrozenSet[Claim] = attr.ib(factory=frozenset)

--- a/degreepath/clause.py
+++ b/degreepath/clause.py
@@ -212,16 +212,20 @@ class SingleClause(_Clause, ResolvedClause):
 
     def rank(self) -> int:
         if self.resolved_with is not None and type(self.resolved_with) in (int, decimal.Decimal, float) and self.operator not in (Operator.LessThan, Operator.LessThanOrEqualTo):
-            if self.resolved_with > self.expected:
-                return int(self.expected)
             return int(self.resolved_with)
+
         if self.result is True:
             return 1
+
         return 0
 
     def max_rank(self) -> int:
+        if self.result is True:
+            return self.rank()
+
         if type(self.expected) in (int, decimal.Decimal, float) and self.operator not in (Operator.LessThan, Operator.LessThanOrEqualTo):
             return int(self.expected)
+
         return 1
 
     def __repr__(self) -> str:

--- a/degreepath/clause.py
+++ b/degreepath/clause.py
@@ -55,7 +55,15 @@ class ResolvedClause:
             "resolved_with": str(self.resolved_with) if self.resolved_with is not None and type(self.resolved_with) is not str else self.resolved_with,
             "resolved_items": [str(x) if isinstance(x, decimal.Decimal) else x for x in self.resolved_items],
             "result": self.result,
+            "rank": self.rank(),
+            "max_rank": self.max_rank(),
         }
+
+    def rank(self) -> int:
+        return 1 if self.result else 0
+
+    def max_rank(self) -> int:
+        return 1
 
 
 @attr.s(frozen=True, cache_hash=True, auto_attribs=True, slots=True)

--- a/degreepath/clause.py
+++ b/degreepath/clause.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Iterable
-from typing import Union, List, Tuple, Dict, Any, Callable, Optional, Sequence, Iterator, cast, TYPE_CHECKING
+from typing import Union, List, Tuple, Dict, Any, Callable, Optional, Iterator, cast, TYPE_CHECKING
 import logging
 import decimal
 import abc

--- a/degreepath/clause.py
+++ b/degreepath/clause.py
@@ -284,18 +284,18 @@ def str_clause(clause: Union[Dict[str, Any], 'Clause']) -> str:
     if clause["type"] == "single-clause":
         resolved_with = clause.get('resolved_with', None)
         if resolved_with is not None:
-            resolved = f" ({resolved_with})"
+            resolved = f" ({repr(resolved_with)})"
         else:
             resolved = ""
 
         if clause['expected'] != clause['expected_verbatim']:
-            postscript = f" (via \"{clause['expected_verbatim']}\")"
+            postscript = f" (via {repr(clause['expected_verbatim'])})"
         else:
             postscript = ""
 
         op = str_operator(clause['operator'])
 
-        return f"\"{clause['key']}\"{resolved} {op} \"{clause['expected']}\"{postscript}"
+        return f'"{clause["key"]}"{resolved} {op} "{clause["expected"]}"{postscript}'
     elif clause["type"] == "or-clause":
         return f'({" or ".join(str_clause(c) for c in clause["children"])})'
     elif clause["type"] == "and-clause":

--- a/degreepath/clause.py
+++ b/degreepath/clause.py
@@ -37,14 +37,14 @@ def load_clause(data: Dict[str, Any], c: Constants) -> 'Clause':
     return AndClause(children=tuple(clauses))
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class _Clause(abc.ABC):
     @abc.abstractmethod
     def compare_and_resolve_with(self, *, value: Any, map_func: Callable) -> 'Clause':
         raise NotImplementedError(f'must define a compare_and_resolve_with() method')
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class ResolvedClause:
     resolved_with: Optional[Any] = None
     resolved_items: Sequence[Any] = tuple()
@@ -58,7 +58,7 @@ class ResolvedClause:
         }
 
 
-@attr.s(frozen=True, cache_hash=True, auto_attribs=True)
+@attr.s(frozen=True, cache_hash=True, auto_attribs=True, slots=True)
 class AndClause(_Clause, ResolvedClause):
     children: Tuple = tuple()
 
@@ -88,7 +88,7 @@ class AndClause(_Clause, ResolvedClause):
         return AndClause(children=children, resolved_with=None, resolved_items=[], result=result)
 
 
-@attr.s(frozen=True, cache_hash=True, auto_attribs=True)
+@attr.s(frozen=True, cache_hash=True, auto_attribs=True, slots=True)
 class OrClause(_Clause, ResolvedClause):
     children: Tuple = tuple()
 
@@ -118,7 +118,7 @@ class OrClause(_Clause, ResolvedClause):
         return OrClause(children=children, resolved_with=None, resolved_items=[], result=result)
 
 
-@attr.s(frozen=True, cache_hash=True, auto_attribs=True)
+@attr.s(frozen=True, cache_hash=True, auto_attribs=True, slots=True)
 class SingleClause(_Clause, ResolvedClause):
     key: str = "???"
     expected: Any = None

--- a/degreepath/clause.py
+++ b/degreepath/clause.py
@@ -52,7 +52,7 @@ class ResolvedClause:
 
     def to_dict(self) -> Dict[str, Any]:
         return {
-            "resolved_with": str(self.resolved_with) if type(self.resolved_with) is not str else self.resolved_with,
+            "resolved_with": str(self.resolved_with) if self.resolved_with is not None and type(self.resolved_with) is not str else self.resolved_with,
             "resolved_items": [str(x) if isinstance(x, decimal.Decimal) else x for x in self.resolved_items],
             "result": self.result,
         }

--- a/degreepath/clause.py
+++ b/degreepath/clause.py
@@ -135,7 +135,7 @@ class OrClause(_Clause, ResolvedClause):
         return sum(c.rank() for c in self.children)
 
     def max_rank(self) -> int:
-        return sum(c.rank() if c.ok else c.max_rank() for c in self.children)
+        return sum(c.rank() if c.result is True else c.max_rank() for c in self.children)
 
 
 @attr.s(frozen=True, cache_hash=True, auto_attribs=True, slots=True)

--- a/degreepath/clause.py
+++ b/degreepath/clause.py
@@ -47,7 +47,7 @@ class _Clause(abc.ABC):
 @attr.s(auto_attribs=True, slots=True)
 class ResolvedClause:
     resolved_with: Optional[Any] = None
-    resolved_items: Sequence[Any] = tuple()
+    resolved_items: Tuple[Any, ...] = tuple()
     result: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
@@ -93,7 +93,7 @@ class AndClause(_Clause, ResolvedClause):
         children = tuple(c.compare_and_resolve_with(value=value, map_func=map_func) for c in self.children)
         result = all(c.result for c in children)
 
-        return AndClause(children=children, resolved_with=None, resolved_items=[], result=result)
+        return AndClause(children=children, resolved_with=None, resolved_items=tuple(), result=result)
 
     def rank(self) -> int:
         return sum(c.rank() for c in self.children)
@@ -129,7 +129,7 @@ class OrClause(_Clause, ResolvedClause):
         children = tuple(c.compare_and_resolve_with(value=value, map_func=map_func) for c in self.children)
         result = any(c.result for c in children)
 
-        return OrClause(children=children, resolved_with=None, resolved_items=[], result=result)
+        return OrClause(children=children, resolved_with=None, resolved_items=tuple(), result=result)
 
     def rank(self) -> int:
         return sum(c.rank() for c in self.children)

--- a/degreepath/constants.py
+++ b/degreepath/constants.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Any
 import logging
 
@@ -12,7 +12,7 @@ VALID_CLAUSE_CONSTANTS = [
 ]
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class Constants:
     matriculation_year: int
 

--- a/degreepath/context.py
+++ b/degreepath/context.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field, replace
+import attr
 from typing import List, Optional, Tuple, Dict, Union, Set, Sequence, Iterable, Iterator
 from collections import defaultdict
 import logging
@@ -15,16 +15,16 @@ logger = logging.getLogger(__name__)
 debug: Optional[bool] = None
 
 
-@dataclass(frozen=False)
+@attr.s(slots=True, kw_only=True, frozen=False, auto_attribs=True)
 class RequirementContext:
-    _transcript: List[CourseInstance] = field(default_factory=list)
-    _course_lookup_map: Dict[str, CourseInstance] = field(default_factory=dict)
-    _clbid_lookup_map: Dict[str, CourseInstance] = field(default_factory=dict)
+    transcript_: List[CourseInstance] = attr.ib(factory=list)
+    course_lookup_map_: Dict[str, CourseInstance] = attr.ib(factory=dict)
+    clbid_lookup_map_: Dict[str, CourseInstance] = attr.ib(factory=dict)
 
     areas: Tuple[AreaPointer, ...] = tuple()
-    multicountable: List[List[SingleClause]] = field(default_factory=list)
-    claims: Dict[str, Set[Claim]] = field(default_factory=lambda: defaultdict(set))
-    exceptions: Dict[Tuple[str, ...], RuleException] = field(default_factory=dict)
+    multicountable: List[List[SingleClause]] = attr.ib(factory=list)
+    claims: Dict[str, Set[Claim]] = attr.ib(factory=lambda: defaultdict(set))
+    exceptions: Dict[Tuple[str, ...], RuleException] = attr.ib(factory=dict)
 
     def with_transcript(self, transcript: Iterable[CourseInstance]) -> 'RequirementContext':
         transcript = list(transcript)
@@ -36,16 +36,16 @@ class RequirementContext:
 
         clbid_lookup_map = {c.clbid: c for c in transcript}
 
-        return replace(self, _transcript=transcript, _course_lookup_map=course_lookup_map, _clbid_lookup_map=clbid_lookup_map)
+        return attr.evolve(self, transcript_=transcript, course_lookup_map_=course_lookup_map, clbid_lookup_map_=clbid_lookup_map)
 
     def transcript(self) -> List[CourseInstance]:
-        return self._transcript
+        return self.transcript_
 
     def find_course(self, c: str) -> Optional[CourseInstance]:
-        return self._course_lookup_map.get(c, None)
+        return self.course_lookup_map_.get(c, None)
 
     def find_course_by_clbid(self, clbid: str) -> Optional[CourseInstance]:
-        return self._clbid_lookup_map.get(clbid, None)
+        return self.clbid_lookup_map_.get(clbid, None)
 
     def forced_course_by_clbid(self, clbid: str) -> CourseInstance:
         match = self.find_course_by_clbid(clbid)

--- a/degreepath/context.py
+++ b/degreepath/context.py
@@ -67,6 +67,9 @@ class RequirementContext:
             logger.debug("no exception for %s", path)
         return self.exceptions.get(tuple(path), None)
 
+    def set_claims(self, claims: Dict[str, Set[Claim]]) -> None:
+        self.claims = defaultdict(set, {k: set(v) for k, v in claims.items()})
+
     def reset_claims(self) -> None:
         self.claims = defaultdict(set)
 

--- a/degreepath/data/area_pointer.py
+++ b/degreepath/data/area_pointer.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any
-import dataclasses
+import attr
 import logging
 
 from ..clause import Clause, SingleClause, AndClause, OrClause
@@ -9,7 +9,7 @@ from .clausable import Clausable
 logger = logging.getLogger(__name__)
 
 
-@dataclasses.dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class AreaPointer(Clausable):
     code: str
     status: AreaStatus

--- a/degreepath/data/course.py
+++ b/degreepath/data/course.py
@@ -14,6 +14,12 @@ Decimal = decimal.Decimal
 
 @dataclasses.dataclass(frozen=True, order=True)
 class CourseInstance(Clausable):
+    __slots__ = (
+        'clbid', 'attributes', 'credits', 'crsid', 'gereqs', 'grade_code', 'grade_option', 'grade_points',
+        'grade_points_gpa', 'is_in_gpa', 'is_in_progress', 'is_incomplete', 'is_repeat', 'is_stolaf', 'is_lab',
+        'level', 'name', 'number', 'section', 'sub_type', 'subject', 'term', 'year', '_identity', '_shorthand',
+    )
+
     clbid: str
     attributes: Tuple[str, ...]
     credits: decimal.Decimal

--- a/degreepath/data/course.py
+++ b/degreepath/data/course.py
@@ -1,5 +1,5 @@
 from typing import Optional, Tuple, List, Dict, Any, Iterator, Iterable
-import dataclasses
+import attr
 import decimal
 import logging
 
@@ -12,14 +12,8 @@ logger = logging.getLogger(__name__)
 Decimal = decimal.Decimal
 
 
-@dataclasses.dataclass(frozen=True, order=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class CourseInstance(Clausable):
-    __slots__ = (
-        'clbid', 'attributes', 'credits', 'crsid', 'gereqs', 'grade_code', 'grade_option', 'grade_points',
-        'grade_points_gpa', 'is_in_gpa', 'is_in_progress', 'is_incomplete', 'is_repeat', 'is_stolaf', 'is_lab',
-        'level', 'name', 'number', 'section', 'sub_type', 'subject', 'term', 'year', '_identity', '_shorthand',
-    )
-
     clbid: str
     attributes: Tuple[str, ...]
     credits: decimal.Decimal
@@ -44,8 +38,8 @@ class CourseInstance(Clausable):
     term: str
     year: int
 
-    _identity: str
-    _shorthand: str
+    identity_: str
+    shorthand_: str
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -78,22 +72,22 @@ class CourseInstance(Clausable):
         if not attributes:
             attributes = tuple()
 
-        return dataclasses.replace(self, attributes=tuple(attributes))
+        return attr.evolve(self, attributes=tuple(attributes))
 
     def course(self) -> str:
-        return self._identity
+        return self.identity_
 
     def course_shorthand(self) -> str:
-        return self._shorthand
+        return self.shorthand_
 
     def course_with_term(self) -> str:
-        return f"{self._shorthand}{self.section or ''} {self.year}-{self.term}"
+        return f"{self.shorthand_}{self.section or ''} {self.year}-{self.term}"
 
     def __str__(self) -> str:
-        return self._shorthand
+        return self.shorthand_
 
     def __repr__(self) -> str:
-        return f'Course("{self._shorthand}")'
+        return f'Course("{self.shorthand_}")'
 
     def apply_clause(self, clause: Clause) -> bool:
         if isinstance(clause, AndClause):
@@ -122,7 +116,7 @@ class CourseInstance(Clausable):
             return clause.compare(self.number)
 
         if clause.key == 'course':
-            return clause.compare(self._identity) or clause.compare(self._shorthand)
+            return clause.compare(self.identity_) or clause.compare(self.shorthand_)
 
         if clause.key == 'subject':
             return clause.compare(self.subject)
@@ -255,8 +249,8 @@ def load_course(data: Dict[str, Any]) -> CourseInstance:  # noqa: C901
         subject=subject,
         term=term,
         year=year,
-        _identity=course_identity,
-        _shorthand=course_identity_short,
+        identity_=course_identity,
+        shorthand_=course_identity_short,
     )
 
 

--- a/degreepath/data/course_enums.py
+++ b/degreepath/data/course_enums.py
@@ -1,4 +1,5 @@
 import enum
+from typing import Any
 
 
 @enum.unique
@@ -22,8 +23,30 @@ class SubType(enum.Enum):
     Normal = ""
 
 
+class OrderedEnum(enum.Enum):
+    def __ge__(self, other: Any) -> Any:
+        if self.__class__ is other.__class__:
+            return self.value >= other.value
+        return NotImplemented
+
+    def __gt__(self, other: Any) -> Any:
+        if self.__class__ is other.__class__:
+            return self.value > other.value
+        return NotImplemented
+
+    def __le__(self, other: Any) -> Any:
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+        return NotImplemented
+
+    def __lt__(self, other: Any) -> Any:
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented
+
+
 @enum.unique
-class GradeCode(enum.Enum):
+class GradeCode(OrderedEnum):
     A = "A"
     Aplus = "A+"
     Aminus = "A-"

--- a/degreepath/exception.py
+++ b/degreepath/exception.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Tuple, Dict, Any
 import logging
 import enum
@@ -13,7 +13,7 @@ class ExceptionAction(enum.Enum):
     Override = "override"
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class RuleException:
     path: Tuple[str, ...]
     type: ExceptionAction
@@ -25,7 +25,7 @@ class RuleException:
         return False
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class InsertionException(RuleException):
     clbid: str
 
@@ -33,7 +33,7 @@ class InsertionException(RuleException):
         return {**super().to_dict(), "clbid": self.clbid}
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class OverrideException(RuleException):
     status: ResultStatus
 

--- a/degreepath/exception.py
+++ b/degreepath/exception.py
@@ -16,10 +16,10 @@ class ExceptionAction(enum.Enum):
 @dataclass(frozen=True)
 class RuleException:
     path: Tuple[str, ...]
-    action: ExceptionAction
+    type: ExceptionAction
 
     def to_dict(self) -> Dict[str, Any]:
-        return {"path": list(self.path), "action": self.action.value}
+        return {"path": list(self.path), "type": self.type.value}
 
     def is_pass_override(self) -> bool:
         return False
@@ -45,9 +45,9 @@ class OverrideException(RuleException):
 
 
 def load_exception(data: Dict[str, Any]) -> RuleException:
-    if data['action'] == 'insert':
-        return InsertionException(clbid=data['clbid'], path=data['path'], action=ExceptionAction.Insert)
-    elif data['action'] == 'override':
-        return OverrideException(status=ResultStatus(data['status']), path=data['path'], action=ExceptionAction.Override)
+    if data['type'] == 'insert':
+        return InsertionException(clbid=data['clbid'], path=data['path'], type=ExceptionAction.Insert)
+    elif data['type'] == 'override':
+        return OverrideException(status=ResultStatus(data['status']), path=data['path'], type=ExceptionAction.Override)
 
-    raise TypeError(f'expected "action" to be "insert" or "override"; got {data["action"]}')
+    raise TypeError(f'expected "type" to be "insert" or "override"; got {data["type"]}')

--- a/degreepath/limit.py
+++ b/degreepath/limit.py
@@ -15,6 +15,7 @@ T = TypeVar('T', bound=Clausable)
 
 @dataclass(frozen=True)
 class Limit:
+    __slots__ = ('at_most', 'where')
     at_most: int
     where: Clause
 
@@ -45,6 +46,7 @@ class Limit:
 
 @dataclass(frozen=True)
 class LimitSet:
+    __slots__ = ('limits',)
     limits: Tuple[Limit, ...]
 
     def has_limits(self) -> bool:

--- a/degreepath/limit.py
+++ b/degreepath/limit.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Dict, Tuple, Sequence, Optional, Iterator, TypeVar, Any, List
 import itertools
 from collections import defaultdict
@@ -13,9 +13,8 @@ logger = logging.getLogger(__name__)
 T = TypeVar('T', bound=Clausable)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class Limit:
-    __slots__ = ('at_most', 'where')
     at_most: int
     where: Clause
 
@@ -44,9 +43,8 @@ class Limit:
                 yield combo
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class LimitSet:
-    __slots__ = ('limits',)
     limits: Tuple[Limit, ...]
 
     def has_limits(self) -> bool:

--- a/degreepath/ms.py
+++ b/degreepath/ms.py
@@ -1,5 +1,5 @@
 from typing import Optional, Union
-import dataclasses
+import attr
 import decimal
 import math
 import re
@@ -9,7 +9,7 @@ def to_zero(dec: decimal.Decimal) -> decimal.Decimal:
     return dec.quantize(decimal.Decimal("1"), rounding=decimal.ROUND_DOWN)
 
 
-@dataclasses.dataclass()
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class Ms:
     days: decimal.Decimal
     hours: decimal.Decimal

--- a/degreepath/ncr.py
+++ b/degreepath/ncr.py
@@ -11,4 +11,4 @@ def ncr(n: int, r: int) -> int:
 
 
 def mult(it: Iterable[int]) -> int:
-    return reduce(op.mul, it, 0)
+    return reduce(op.mul, it, 1)

--- a/degreepath/operator.py
+++ b/degreepath/operator.py
@@ -47,6 +47,9 @@ def apply_operator(*, op: Operator, lhs: Any, rhs: Any) -> bool:
     debug = __debug__ and logger.isEnabledFor(logging.DEBUG)
     if debug: logger.debug("lhs=`%s` op=%s rhs=`%s` (%s, %s)", lhs, op.name, rhs, type(lhs), type(rhs))
 
+    if lhs is None or rhs is None and lhs != rhs:
+        return False
+
     if isinstance(lhs, tuple) and isinstance(rhs, tuple):
         if op is not Operator.In:
             raise Exception('both rhs and lhs must not be sequences when using %s; lhs=%s, rhs=%s', op, lhs, rhs)

--- a/degreepath/operator.py
+++ b/degreepath/operator.py
@@ -47,7 +47,7 @@ def apply_operator(*, op: Operator, lhs: Any, rhs: Any) -> bool:
     debug = __debug__ and logger.isEnabledFor(logging.DEBUG)
     if debug: logger.debug("lhs=`%s` op=%s rhs=`%s` (%s, %s)", lhs, op.name, rhs, type(lhs), type(rhs))
 
-    if lhs is None or rhs is None and lhs != rhs:
+    if (lhs is None or rhs is None) and lhs != rhs:
         return False
 
     if isinstance(lhs, tuple) and isinstance(rhs, tuple):

--- a/degreepath/result/assertion.py
+++ b/degreepath/result/assertion.py
@@ -27,9 +27,3 @@ class AssertionResult(Result, BaseAssertionRule):
             return True
 
         return self.assertion.result is True
-
-    def rank(self) -> int:
-        return 0
-
-    def max_rank(self) -> int:
-        return 0

--- a/degreepath/result/assertion.py
+++ b/degreepath/result/assertion.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import TYPE_CHECKING
 
 from ..base.bases import Result
@@ -8,9 +8,8 @@ if TYPE_CHECKING:
     from ..context import RequirementContext  # noqa: F401
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class AssertionResult(Result, BaseAssertionRule):
-    __slots__ = ('overridden',)
     overridden: bool
 
     def validate(self, *, ctx: 'RequirementContext') -> None:

--- a/degreepath/result/assertion.py
+++ b/degreepath/result/assertion.py
@@ -10,7 +10,8 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class AssertionResult(Result, BaseAssertionRule):
-    overridden: bool = False
+    __slots__ = ('overridden',)
+    overridden: bool
 
     def validate(self, *, ctx: 'RequirementContext') -> None:
         if self.where:

--- a/degreepath/result/count.py
+++ b/degreepath/result/count.py
@@ -48,9 +48,3 @@ class CountResult(Result, BaseCountRule):
         passed_count = sum(1 if r.ok() else 0 for r in self.items)
         audit_passed = len(self.audit_results) == 0 or all(a.ok() for a in self.audit_results)
         return passed_count >= self.count and audit_passed
-
-    def rank(self) -> int:
-        return sum(r.rank() for r in self.items)
-
-    def max_rank(self) -> int:
-        return sum(r.max_rank() for r in self.items)

--- a/degreepath/result/count.py
+++ b/degreepath/result/count.py
@@ -1,13 +1,12 @@
-from dataclasses import dataclass
+import attr
 from typing import Tuple, Union, Sequence, List
 
 from ..base import Result, BaseCountRule, Rule, ResultStatus, Solution, BaseAssertionRule
 from ..claim import ClaimAttempt
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class CountResult(Result, BaseCountRule):
-    __slots__ = ('audit_results', 'overridden')
     audit_results: Tuple[BaseAssertionRule, ...]
     overridden: bool
 

--- a/degreepath/result/count.py
+++ b/degreepath/result/count.py
@@ -48,3 +48,9 @@ class CountResult(Result, BaseCountRule):
         passed_count = sum(1 if r.ok() else 0 for r in self.items)
         audit_passed = len(self.audit_results) == 0 or all(a.ok() for a in self.audit_results)
         return passed_count >= self.count and audit_passed
+
+    def max_rank(self) -> int:
+        if self.ok():
+            return self.rank()
+
+        return super().max_rank()

--- a/degreepath/result/count.py
+++ b/degreepath/result/count.py
@@ -7,8 +7,9 @@ from ..claim import ClaimAttempt
 
 @dataclass(frozen=True)
 class CountResult(Result, BaseCountRule):
+    __slots__ = ('audit_results', 'overridden')
     audit_results: Tuple[BaseAssertionRule, ...]
-    overridden: bool = False
+    overridden: bool
 
     @staticmethod
     def from_solution(

--- a/degreepath/result/course.py
+++ b/degreepath/result/course.py
@@ -57,9 +57,3 @@ class CourseResult(Result, BaseCourseRule):
             return True
 
         return self.claim_attempt is not None and self.claim_attempt.failed() is False and self.min_grade_not_met is None
-
-    def rank(self) -> int:
-        return 1 if self.ok() else 0
-
-    def max_rank(self) -> int:
-        return 1

--- a/degreepath/result/course.py
+++ b/degreepath/result/course.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Optional, List, Dict, Any, TYPE_CHECKING
 
 from ..base import Result, BaseCourseRule
@@ -8,9 +8,8 @@ if TYPE_CHECKING:
     from ..data import CourseInstance  # noqa: F401
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class CourseResult(Result, BaseCourseRule):
-    __slots__ = ('claim_attempt', 'min_grade_not_met', 'overridden')
     claim_attempt: Optional['ClaimAttempt']
     min_grade_not_met: Optional['CourseInstance']
     overridden: bool

--- a/degreepath/result/course.py
+++ b/degreepath/result/course.py
@@ -10,9 +10,10 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class CourseResult(Result, BaseCourseRule):
+    __slots__ = ('claim_attempt', 'min_grade_not_met', 'overridden')
     claim_attempt: Optional['ClaimAttempt']
-    min_grade_not_met: Optional['CourseInstance'] = None
-    overridden: bool = False
+    min_grade_not_met: Optional['CourseInstance']
+    overridden: bool
 
     @staticmethod
     def from_solution(

--- a/degreepath/result/query.py
+++ b/degreepath/result/query.py
@@ -8,11 +8,12 @@ from ..claim import ClaimAttempt
 
 @dataclass(frozen=True)
 class QueryResult(Result, BaseQueryRule):
+    __slots__ = ('successful_claims', 'failed_claims', 'resolved_assertions', 'success', 'overridden')
     successful_claims: Tuple[ClaimAttempt, ...]
     failed_claims: Tuple[ClaimAttempt, ...]
     resolved_assertions: Tuple[AssertionResult, ...]
     success: bool
-    overridden: bool = False
+    overridden: bool
 
     @staticmethod
     def from_solution(

--- a/degreepath/result/query.py
+++ b/degreepath/result/query.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Tuple, Dict, Any, List
 from .assertion import AssertionResult
 
@@ -6,9 +6,8 @@ from ..base import Result, BaseQueryRule
 from ..claim import ClaimAttempt
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class QueryResult(Result, BaseQueryRule):
-    __slots__ = ('successful_claims', 'failed_claims', 'resolved_assertions', 'success', 'overridden')
     successful_claims: Tuple[ClaimAttempt, ...]
     failed_claims: Tuple[ClaimAttempt, ...]
     resolved_assertions: Tuple[AssertionResult, ...]

--- a/degreepath/result/query.py
+++ b/degreepath/result/query.py
@@ -62,7 +62,7 @@ class QueryResult(Result, BaseQueryRule):
         return self.success is True
 
     def rank(self) -> int:
-        return len(self.successful_claims) + int(len(self.failed_claims) * 0.5)
+        return sum(a.rank() for a in self.resolved_assertions)
 
     def max_rank(self) -> int:
-        return len(self.successful_claims) + len(self.failed_claims)
+        return sum(a.max_rank() for a in self.resolved_assertions)

--- a/degreepath/result/requirement.py
+++ b/degreepath/result/requirement.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Optional, List, TYPE_CHECKING
 import logging
 
@@ -10,9 +10,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class RequirementResult(Result, BaseRequirementRule):
-    __slots__ = ('overridden',)
     overridden: bool
 
     @staticmethod

--- a/degreepath/result/requirement.py
+++ b/degreepath/result/requirement.py
@@ -54,7 +54,6 @@ class RequirementResult(Result, BaseRequirementRule):
         if self.was_overridden():
             return self.overridden
 
-        # return True if self.audited_by is not None else _ok
         return self.result.ok() if self.result else False
 
     def rank(self) -> int:

--- a/degreepath/result/requirement.py
+++ b/degreepath/result/requirement.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class RequirementResult(Result, BaseRequirementRule):
-    overridden: bool = False
+    __slots__ = ('overridden',)
+    overridden: bool
 
     @staticmethod
     def from_solution(

--- a/degreepath/result/requirement.py
+++ b/degreepath/result/requirement.py
@@ -55,10 +55,3 @@ class RequirementResult(Result, BaseRequirementRule):
             return self.overridden
 
         return self.result.ok() if self.result else False
-
-    def rank(self) -> int:
-        boost = 1 if self.ok() else 0
-        return self.result.rank() + boost if self.result else 0
-
-    def max_rank(self) -> int:
-        return self.result.max_rank() + 1 if self.result else 0

--- a/degreepath/rule/assertion.py
+++ b/degreepath/rule/assertion.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Sequence, Iterator, TYPE_CHECKING
+from typing import Dict, Sequence, Iterator, Collection, TYPE_CHECKING
 import logging
 
 from ..clause import load_clause
@@ -9,6 +9,7 @@ from ..base.assertion import BaseAssertionRule
 
 if TYPE_CHECKING:
     from ..context import RequirementContext
+    from ..data import Clausable  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -48,4 +49,7 @@ class AssertionRule(Rule, BaseAssertionRule):
         raise Exception('this method should not be called')
 
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
+        raise Exception('this method should not be called')
+
+    def all_matches(self, *, ctx: 'RequirementContext') -> Collection['Clausable']:
         raise Exception('this method should not be called')

--- a/degreepath/rule/assertion.py
+++ b/degreepath/rule/assertion.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Dict, Sequence, Iterator, Collection, Optional, TYPE_CHECKING
 import logging
 
@@ -14,10 +14,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class AssertionRule(Rule, BaseAssertionRule):
-    __slots__ = ()
-
     @staticmethod
     def can_load(data: Dict) -> bool:
         if "assert" in data:

--- a/degreepath/rule/assertion.py
+++ b/degreepath/rule/assertion.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Sequence, Iterator, Collection, TYPE_CHECKING
+from typing import Dict, Sequence, Iterator, Collection, Optional, TYPE_CHECKING
 import logging
 
 from ..clause import load_clause
@@ -45,7 +45,7 @@ class AssertionRule(Rule, BaseAssertionRule):
         logger.debug('AssertionRule.estimate: 0')
         return 0
 
-    def solutions(self, *, ctx: 'RequirementContext') -> Iterator[Solution]:
+    def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[Solution]:
         raise Exception('this method should not be called')
 
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:

--- a/degreepath/rule/assertion.py
+++ b/degreepath/rule/assertion.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class AssertionRule(Rule, BaseAssertionRule):
+    __slots__ = ()
+
     @staticmethod
     def can_load(data: Dict) -> bool:
         if "assert" in data:

--- a/degreepath/rule/count.py
+++ b/degreepath/rule/count.py
@@ -3,12 +3,11 @@ from typing import Dict, List, Sequence, Tuple, Iterator, Collection, Set, Froze
 import itertools
 import logging
 
-from ..base import Rule, BaseCountRule, Result, Solution
+from ..base import Rule, BaseCountRule, Result
 from ..constants import Constants
 from ..exception import InsertionException
 from ..solution.count import CountSolution
 from ..ncr import mult
-from ..stringify import print_result
 from .course import CourseRule
 from .assertion import AssertionRule
 
@@ -224,6 +223,9 @@ class CountRule(Rule, BaseCountRule):
             # itertools.product does this internally, so we'll pre-compute the results here
             # to make it obvious that it's not lazy
             solutions = [tuple(r.solutions(ctx=ctx)) for r in selected_children]
+
+            lengths = [len(s) for s in solutions]
+            logger.debug(f"emitting {mult(lengths):,} solutions (%s)", lengths)
 
             for solset_i, solutionset in enumerate(itertools.product(*solutions)):
                 if debug and solset_i > 0 and solset_i % 10_000 == 0:

--- a/degreepath/rule/count.py
+++ b/degreepath/rule/count.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class CountRule(Rule, BaseCountRule):
     __slots__ = ()
-    
+
     items: Tuple[Rule, ...]
 
     @staticmethod

--- a/degreepath/rule/count.py
+++ b/degreepath/rule/count.py
@@ -240,7 +240,7 @@ class CountRule(Rule, BaseCountRule):
             solutions = [tuple(r.solutions(ctx=ctx)) for r in selected_children]
 
             lengths = [len(s) for s in solutions]
-            logger.debug(f"emitting {mult(lengths):,} solutions (%s)", lengths)
+            logger.debug(f"%s emitting {mult(lengths):,} solutions (%s)" % (self.path, lengths))
 
             solutionset: Tuple[Union[Rule, Solution, Result], ...]
             for solset_i, solutionset in enumerate(itertools.product(*solutions)):

--- a/degreepath/rule/count.py
+++ b/degreepath/rule/count.py
@@ -241,7 +241,6 @@ class CountRule(Rule, BaseCountRule):
             solutions = tuple(solutions_dict.values())
 
             lengths = {r.path: len(s) for r, s in solutions_dict.items()}
-            print(lengths)
             logger.debug(f"%s emitting {mult(lengths.values()):,} solutions (%s)" % (self.path, lengths))
 
             solutionset: Tuple[Union[Rule, Solution, Result], ...]

--- a/degreepath/rule/count.py
+++ b/degreepath/rule/count.py
@@ -148,12 +148,12 @@ class CountRule(Rule, BaseCountRule):
                 hidden=False,
                 grade=None,
                 allow_claimed=False,
-                path=tuple([*self.path, f"*{matched_course.course()}"]),
+                path=tuple([*self.path, f"[{len(items)}]", f"*{matched_course.course()}"]),
             )
 
             logger.debug("new choice at %s is %s", self.path, new_rule)
 
-            items = tuple([new_rule, *self.items])
+            items = tuple([*items, new_rule])
 
         lo = count
         hi = len(items) + 1 if self.at_most is False else count + 1

--- a/degreepath/rule/count.py
+++ b/degreepath/rule/count.py
@@ -161,7 +161,7 @@ class CountRule(Rule, BaseCountRule):
         logger.debug('%s discovering children with potential', self.path)
         all_potential_rules = set(rule for rule in items if rule.has_potential(ctx=ctx))
 
-        if depth == 1 and all_potential_rules:
+        if depth == 1 and all_potential_rules and not self.audit_clauses:
             logger.debug('%s searching for disjoint children', self.path)
             separated_children = self.find_independent_children(items=all_potential_rules, ctx=ctx)
 

--- a/degreepath/rule/count.py
+++ b/degreepath/rule/count.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class CountRule(Rule, BaseCountRule):
+    __slots__ = ()
+    
     items: Tuple[Rule, ...]
 
     @staticmethod

--- a/degreepath/rule/course.py
+++ b/degreepath/rule/course.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class CourseRule(Rule, BaseCourseRule):
+    __slots__ = ()
+
     @staticmethod
     def can_load(data: Dict) -> bool:
         if "course" in data:

--- a/degreepath/rule/course.py
+++ b/degreepath/rule/course.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Iterator, Collection, TYPE_CHECKING
+from typing import Dict, List, Iterator, Collection, Optional, TYPE_CHECKING
 import re
 import logging
 
@@ -48,7 +48,7 @@ class CourseRule(Rule, BaseCourseRule):
 
         assert (method_a or method_b or method_c) is not None, f"{self.course}, {method_a}, {method_b}, {method_c}"
 
-    def solutions(self, *, ctx: 'RequirementContext') -> Iterator[CourseSolution]:
+    def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[CourseSolution]:
         exception = ctx.get_exception(self.path)
         if exception and exception.is_pass_override():
             logger.debug("forced override on %s", self.path)

--- a/degreepath/rule/course.py
+++ b/degreepath/rule/course.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Dict, List, Iterator, Collection, Optional, TYPE_CHECKING
 import re
 import logging
@@ -16,10 +16,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class CourseRule(Rule, BaseCourseRule):
-    __slots__ = ()
-
     @staticmethod
     def can_load(data: Dict) -> bool:
         if "course" in data:

--- a/degreepath/rule/course.py
+++ b/degreepath/rule/course.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Iterator, TYPE_CHECKING
+from typing import Dict, List, Iterator, Collection, TYPE_CHECKING
 import re
 import logging
 
@@ -7,9 +7,11 @@ from ..base import Rule, BaseCourseRule
 from ..constants import Constants
 from ..lib import str_to_grade_points
 from ..solution.course import CourseSolution
+from ..exception import InsertionException
 
 if TYPE_CHECKING:
     from ..context import RequirementContext
+    from ..data import Clausable  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -77,3 +79,12 @@ class CourseRule(Rule, BaseCourseRule):
             return True
 
         return False
+
+    def all_matches(self, *, ctx: 'RequirementContext') -> Collection['Clausable']:
+        exception = ctx.get_exception(self.path)
+        if exception and isinstance(exception, InsertionException):
+            match = ctx.find_course_by_clbid(exception.clbid)
+        else:
+            match = ctx.find_course(self.course)
+
+        return [match] if match else []

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -109,7 +109,7 @@ class QueryRule(Rule, BaseQueryRule):
             logger.info("%s not yet implemented", self.source_type)
             return []
 
-    def solutions(self, *, ctx: 'RequirementContext') -> Iterator[QuerySolution]:  # noqa: C901
+    def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[QuerySolution]:  # noqa: C901
         debug = __debug__ and logger.isEnabledFor(logging.DEBUG)
 
         exception = ctx.get_exception(self.path)

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -254,7 +254,7 @@ def has_clause(clause: Clause, key: Any) -> bool:
 
 
 def get_simple_count_clauses(clause: Clause) -> Iterator[SingleClause]:
-    if isinstance(clause, SingleClause) and clause.key == 'count(courses)':
+    if isinstance(clause, SingleClause) and clause.key in ('count(courses)', 'count(terms)'):
         yield clause
     elif isinstance(clause, OrClause) or isinstance(clause, AndClause):
         for c in clause.children:

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Dict, List, Optional, Set, Sequence, Iterator, Collection, Any, TYPE_CHECKING
 import itertools
 import logging
@@ -21,10 +21,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class QueryRule(Rule, BaseQueryRule):
-    __slots__ = ()
-
     @staticmethod
     def can_load(data: Dict) -> bool:
         if "from" in data:

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -210,6 +210,12 @@ class QueryRule(Rule, BaseQueryRule):
 
         return any(item.apply_clause(self.where) for item in self.get_data(ctx=ctx))
 
+    def rank(self) -> int:
+        return 0
+
+    def max_rank(self) -> int:
+        return len(self.assertions)
+
 
 def has_assertion(assertions: Sequence[AssertionRule], key: Any) -> bool:
     if not assertions:

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class QueryRule(Rule, BaseQueryRule):
+    __slots__ = ()
+
     @staticmethod
     def can_load(data: Dict) -> bool:
         if "from" in data:

--- a/degreepath/rule/requirement.py
+++ b/degreepath/rule/requirement.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class RequirementRule(Rule, BaseRequirementRule):
+    __slots__ = ()
+
     result: Optional[Rule]
 
     def status(self) -> ResultStatus:

--- a/degreepath/rule/requirement.py
+++ b/degreepath/rule/requirement.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Mapping, Optional, List, Iterator, Collection, TYPE_CHECKING
 import logging
 
@@ -66,7 +66,7 @@ class RequirementRule(Rule, BaseRequirementRule):
         if self.result is not None:
             self.result.validate(ctx=ctx)
 
-    def solutions(self, *, ctx: 'RequirementContext') -> Iterator[RequirementSolution]:
+    def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[RequirementSolution]:
         exception = ctx.get_exception(self.path)
         if exception and exception.is_pass_override():
             logger.debug("forced override on %s", self.path)

--- a/degreepath/rule/requirement.py
+++ b/degreepath/rule/requirement.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Any, Mapping, Optional, List, Iterator, Collection, TYPE_CHECKING
 import logging
 
@@ -14,10 +14,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class RequirementRule(Rule, BaseRequirementRule):
-    __slots__ = ()
-
     result: Optional[Rule]
 
     def status(self) -> ResultStatus:

--- a/degreepath/rule/requirement.py
+++ b/degreepath/rule/requirement.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, replace
-from typing import Any, Mapping, Optional, List, Iterator, TYPE_CHECKING
+from typing import Any, Mapping, Optional, List, Iterator, Collection, TYPE_CHECKING
 import logging
 
 from ..base import Rule, BaseRequirementRule, ResultStatus
@@ -9,6 +9,7 @@ from ..solution.requirement import RequirementSolution
 
 if TYPE_CHECKING:
     from ..context import RequirementContext
+    from ..data import Clausable  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -117,3 +118,9 @@ class RequirementRule(Rule, BaseRequirementRule):
             return self.result.has_potential(ctx=ctx)
 
         return False
+
+    def all_matches(self, *, ctx: 'RequirementContext') -> Collection['Clausable']:
+        if not self.result:
+            return []
+
+        return self.result.all_matches(ctx=ctx)

--- a/degreepath/rule/requirement.py
+++ b/degreepath/rule/requirement.py
@@ -63,10 +63,8 @@ class RequirementRule(Rule, BaseRequirementRule):
             assert isinstance(self.message, str)
             assert self.message.strip() != ""
 
-        new_ctx = replace(ctx)
-
         if self.result is not None:
-            self.result.validate(ctx=new_ctx)
+            self.result.validate(ctx=ctx)
 
     def solutions(self, *, ctx: 'RequirementContext') -> Iterator[RequirementSolution]:
         exception = ctx.get_exception(self.path)
@@ -85,9 +83,7 @@ class RequirementRule(Rule, BaseRequirementRule):
             yield RequirementSolution.from_rule(rule=self, solution=None)
             return
 
-        new_ctx = replace(ctx)
-
-        for solution in self.result.solutions(ctx=new_ctx):
+        for solution in self.result.solutions(ctx=ctx):
             yield RequirementSolution.from_rule(rule=self, solution=solution)
 
     def estimate(self, *, ctx: 'RequirementContext') -> int:

--- a/degreepath/solution/count.py
+++ b/degreepath/solution/count.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Tuple, Union, TYPE_CHECKING
 import logging
 
@@ -13,9 +13,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class CountSolution(Solution, BaseCountRule):
-    __slots__ = ('overridden',)
     overridden: bool
 
     @staticmethod

--- a/degreepath/solution/count.py
+++ b/degreepath/solution/count.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class CountSolution(Solution, BaseCountRule):
-    overridden: bool = False
+    __slots__ = ('overridden',)
+    overridden: bool
 
     @staticmethod
     def from_rule(*, rule: BaseCountRule, count: int, items: Tuple[Union[Rule, Solution, Result], ...], overridden: bool = False) -> 'CountSolution':
@@ -69,6 +70,7 @@ class CountSolution(Solution, BaseCountRule):
                 where=clause.where,
                 assertion=result,
                 path=clause.path,
+                overridden=False,
             ))
 
         return CountResult.from_solution(

--- a/degreepath/solution/course.py
+++ b/degreepath/solution/course.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class CourseSolution(Solution, BaseCourseRule):
-    overridden: bool = False
+    __slots__ = ('overridden',)
+    overridden: bool
 
     @staticmethod
     def from_rule(*, rule: BaseCourseRule, overridden: bool = False) -> 'CourseSolution':

--- a/degreepath/solution/course.py
+++ b/degreepath/solution/course.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import TYPE_CHECKING
 import logging
 
@@ -13,9 +13,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class CourseSolution(Solution, BaseCourseRule):
-    __slots__ = ('overridden',)
     overridden: bool
 
     @staticmethod

--- a/degreepath/solution/query.py
+++ b/degreepath/solution/query.py
@@ -172,7 +172,7 @@ def count_items(data: Sequence[Union[CourseInstance, AreaPointer]], kind: str) -
         counted = Counter(c.crsid for c in data)
         most_common = counted.most_common(1)[0]
         most_common_crsid, _count = most_common
-        items = frozenset(c.term for c in data if c.crsid == most_common_crsid)
+        items = frozenset(str(c.year) + str(c.term) for c in data if c.crsid == most_common_crsid)
         return (len(items), items)
 
     if kind == 'subjects':

--- a/degreepath/solution/query.py
+++ b/degreepath/solution/query.py
@@ -184,7 +184,7 @@ def count_items(data: Sequence[Union[CourseInstance, AreaPointer]], kind: str) -
     if kind == 'terms':
         assert all(isinstance(x, CourseInstance) for x in data)
         data = cast(Tuple[CourseInstance, ...], data)
-        items = frozenset(c.term for c in data)
+        items = frozenset(str(c.year) + str(c.term) for c in data)
         return (len(items), items)
 
     if kind == 'years':

--- a/degreepath/solution/query.py
+++ b/degreepath/solution/query.py
@@ -112,9 +112,9 @@ class QuerySolution(Solution, BaseQueryRule):
 
         if debug:
             if resolved_result:
-                logger.debug("%s from-rule '%s' might possibly succeed", self.path, self)
+                logger.debug("%s might possibly succeed", self.path)
             else:
-                logger.debug("%s from-rule '%s' did not succeed", self.path, self)
+                logger.debug("%s did not succeed", self.path)
 
         return QueryResult.from_solution(
             solution=self,

--- a/degreepath/solution/query.py
+++ b/degreepath/solution/query.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import List, Sequence, Any, Tuple, Collection, Union, FrozenSet, Dict, cast, TYPE_CHECKING
 from collections import Counter
 import logging
@@ -20,9 +20,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class QuerySolution(Solution, BaseQueryRule):
-    __slots__ = ('output', 'overridden')
     output: Tuple[Clausable, ...]
     overridden: bool
 

--- a/degreepath/solution/query.py
+++ b/degreepath/solution/query.py
@@ -22,8 +22,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class QuerySolution(Solution, BaseQueryRule):
+    __slots__ = ('output', 'overridden')
     output: Tuple[Clausable, ...]
-    overridden: bool = False
+    overridden: bool
 
     @staticmethod
     def from_rule(*, rule: BaseQueryRule, output: Tuple[Clausable, ...], overridden: bool = False) -> 'QuerySolution':
@@ -137,7 +138,7 @@ class QuerySolution(Solution, BaseQueryRule):
             filtered_output = [item for item in output if item.apply_clause(clause.where)]
 
         result = clause.assertion.compare_and_resolve_with(value=filtered_output, map_func=apply_clause_to_query_rule)
-        return AssertionResult(where=clause.where, assertion=result, path=clause.path)
+        return AssertionResult(where=clause.where, assertion=result, path=clause.path, overridden=False)
 
 
 def apply_clause_to_query_rule(*, value: Sequence[Union[CourseInstance, AreaPointer]], clause: SingleClause) -> Tuple[Union[decimal.Decimal, int], Collection[Any]]:

--- a/degreepath/solution/requirement.py
+++ b/degreepath/solution/requirement.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import attr
 from typing import Optional, Union, List, TYPE_CHECKING
 
 from ..base import BaseRequirementRule, Solution, Rule
@@ -9,9 +9,8 @@ if TYPE_CHECKING:
     from ..claim import ClaimAttempt  # noqa: F401
 
 
-@dataclass(frozen=True)
+@attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class RequirementSolution(Solution, BaseRequirementRule):
-    __slots__ = ('overridden',)
     result: Optional[Union[Rule, Solution]]
     overridden: bool
 

--- a/degreepath/solution/requirement.py
+++ b/degreepath/solution/requirement.py
@@ -11,8 +11,9 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class RequirementSolution(Solution, BaseRequirementRule):
+    __slots__ = ('overridden',)
     result: Optional[Union[Rule, Solution]]
-    overridden: bool = False
+    overridden: bool
 
     @staticmethod
     def from_rule(*, rule: BaseRequirementRule, solution: Optional[Union[Rule, Solution]], overridden: bool = False) -> 'RequirementSolution':

--- a/degreepath/stringify.py
+++ b/degreepath/stringify.py
@@ -3,7 +3,6 @@ from .clause import str_clause, get_resolved_items
 from .data import CourseInstance
 from .ms import pretty_ms
 import json
-import decimal
 
 
 def summarize(
@@ -13,34 +12,14 @@ def summarize(
     count: int,
     elapsed: str,
     iterations: List[float],
-    gpa: decimal.Decimal,
 ) -> Iterator[str]:
     avg_iter_s = sum(iterations) / max(len(iterations), 1)
     avg_iter_time = pretty_ms(avg_iter_s * 1_000, format_sub_ms=True, unit_count=1)
 
     endl = "\n"
 
-    if result['ok']:
-        yield f"audit was successful."
-    else:
-        yield f"audit failed."
-
-    yield f" (rank {result['rank']} of {result['max_rank']})"
-
-    yield f" (gpa: {gpa})"
-
-    yield endl
-
     word = "attempt" if count == 1 else "attempts"
     yield f"{count:,} {word} in {elapsed} (avg {avg_iter_time} per attempt)"
-    yield endl
-
-    yield endl
-
-    yield "Results"
-    yield endl
-    yield "======="
-
     yield endl
     yield endl
 
@@ -60,7 +39,19 @@ def print_result(rule: Dict[str, Any], transcript: List[CourseInstance], indent:
 
     prefix += f"({rank}|{'t' if rule['ok'] else 'f'}) "
 
-    if rule_type == "course":
+    if rule_type == "area":
+        if rule['ok']:
+            title = f"{rule['name']!r} audit was successful."
+        else:
+            title = f"{rule['name']!r} audit failed."
+
+        yield f"{title} (rank {rule['rank']} of {rule['max_rank']}; gpa: {rule['gpa']})"
+
+        yield ""
+
+        yield from print_result(rule['result'], transcript)
+
+    elif rule_type == "course":
         status = "🌀      "
         if rule["ok"]:
             if not rule["overridden"]:

--- a/degreepath/stringify.py
+++ b/degreepath/stringify.py
@@ -36,7 +36,7 @@ def print_result(rule: Dict[str, Any], transcript: List[CourseInstance], indent:
     max_rank = rule["max_rank"]
     path = rule["path"]
 
-    yield f"{prefix} {json.dumps(path)}"
+    yield f"{prefix}{json.dumps(path)}"
 
     prefix += f"({rank}|{max_rank}|{'t' if rule['ok'] else 'f'}) "
 

--- a/degreepath/stringify.py
+++ b/degreepath/stringify.py
@@ -56,7 +56,7 @@ def print_result(rule: Dict[str, Any], transcript: List[CourseInstance], indent:
     rank = rule["rank"]
     path = rule["path"]
 
-    yield f"{prefix}{path}"
+    yield f"{prefix}{json.dumps(path)}"
 
     prefix += f"({rank}|{'t' if rule['ok'] else 'f'}) "
 

--- a/dp-common.py
+++ b/dp-common.py
@@ -4,6 +4,8 @@ import pathlib
 from typing import Iterator
 
 import yaml
+import csv
+import sys
 
 from degreepath import load_course, Constants, AreaPointer, load_exception
 from degreepath.data import GradeOption
@@ -33,11 +35,13 @@ def run(args: Arguments, *, transcript_only: bool = False) -> Iterator[Message]:
         ]
 
         if transcript_only:
-            print('\t'.join(['course', 'clbid', 'credits', 'name', 'year', 'term', 'type', 'gereqs', 'is_repeat', 'in_gpa']))
+            writer = csv.writer(sys.stdout)
+            writer.writerow(['course', 'clbid', 'credits', 'name', 'year', 'term', 'type', 'gereqs', 'is_repeat', 'in_gpa'])
             for c in transcript:
-                items = [c.course(), c.clbid, str(c.credits), c.name, str(c.year), str(c.term),
-                         c.sub_type.name, ','.join(c.gereqs), str(c.is_repeat), str(c.is_in_gpa)]
-                print('\t'.join(items))
+                writer.writerow([
+                    c.course(), c.clbid, str(c.credits), c.name, str(c.year), str(c.term),
+                    c.sub_type.name, ','.join(c.gereqs), str(c.is_repeat), str(c.is_in_gpa),
+                ])
             return
 
         for area_file in args.area_files:

--- a/dp-common.py
+++ b/dp-common.py
@@ -27,10 +27,10 @@ def run(args: Arguments, *, transcript_only: bool = False) -> Iterator[Message]:
         constants = Constants(matriculation_year=student['matriculation'])
 
         if transcript_only:
-            print('\t'.join(['course', 'credits', 'name', 'year', 'term', 'type', 'gereqs', 'in_gpa']))
+            print('\t'.join(['course', 'clbid', 'credits', 'name', 'year', 'term', 'type', 'gereqs', 'is_repeat', 'in_gpa']))
             for c in transcript:
-                items = [c.course(), str(c.credits), c.name, str(c.year), str(c.term),
-                         c.sub_type.name, ','.join(c.gereqs), str(c.is_in_gpa)]
+                items = [c.course(), c.clbid, str(c.credits), c.name, str(c.year), str(c.term),
+                         c.sub_type.name, ','.join(c.gereqs), str(c.is_repeat), str(c.is_in_gpa)]
                 print('\t'.join(items))
             return
 

--- a/dp.py
+++ b/dp.py
@@ -80,10 +80,9 @@ def main() -> None:
 
 def result_str(msg: ResultMsg, *, as_json: bool = False, as_raw: bool = False, gpa_only: bool = False) -> str:
     if gpa_only:
-        return f"GPA: {msg.gpa}"
+        return f"GPA: {msg.result.gpa()}"
 
     dict_result = msg.result.to_dict()
-    dict_result['gpa'] = str(msg.gpa)
 
     if as_json:
         return json.dumps(dict_result)
@@ -91,10 +90,7 @@ def result_str(msg: ResultMsg, *, as_json: bool = False, as_raw: bool = False, g
     if as_raw:
         return repr(msg.result)
 
-    return "\n" + "".join(summarize(
-        result=dict_result, transcript=msg.transcript, gpa=msg.gpa,
-        count=msg.count, elapsed=msg.elapsed, iterations=msg.iterations,
-    ))
+    return "\n" + "".join(summarize(result=dict_result, transcript=msg.transcript, count=msg.count, elapsed=msg.elapsed, iterations=msg.iterations))
 
 
 def display_top(snapshot, key_type='lineno', limit=10):

--- a/dp.py
+++ b/dp.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 logformat = "%(asctime)s %(name)s %(levelname)s %(message)s"
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--area", dest="area_files", nargs="+", required=True)
     parser.add_argument("--student", dest="student_files", nargs="+", required=True)
@@ -27,6 +27,7 @@ def main() -> None:
     parser.add_argument("--estimate", action='store_true')
     parser.add_argument("--transcript", action='store_true')
     parser.add_argument("--gpa", action='store_true')
+    parser.add_argument("-q", "--quiet", action='store_true')
     parser.add_argument("--tracemalloc-init", action='store_true')
     parser.add_argument("--tracemalloc-end", action='store_true')
     cli_args = parser.parse_args()
@@ -42,40 +43,55 @@ def main() -> None:
 
     for msg in dp['run'](args, transcript_only=cli_args.transcript):
         if isinstance(msg, NoStudentsMsg):
-            logger.critical('no student files provided')
+            if not cli_args.quiet:
+                logger.critical('no student files provided')
+            return 3
 
         elif isinstance(msg, NoAuditsCompletedMsg):
-            logger.critical('no audits completed')
+            if not cli_args.quiet:
+                logger.critical('no audits completed')
+            return 2
 
         elif isinstance(msg, AuditStartMsg):
-            print(f"auditing #{msg.stnum} against {msg.area_catalog} {msg.area_code}", file=sys.stderr)
+            if not cli_args.quiet:
+                print(f"auditing #{msg.stnum} against {msg.area_catalog} {msg.area_code}", file=sys.stderr)
 
         elif isinstance(msg, ExceptionMsg):
-            logger.critical("%s %s", msg.ex, msg.tb)
+            if not cli_args.quiet:
+                logger.critical("%s %s", msg.ex, msg.tb)
+            return 1
 
         elif isinstance(msg, ProgressMsg):
             if cli_args.tracemalloc_init:
                 snapshot = tracemalloc.take_snapshot()
                 display_top(snapshot)
-                return
+                return 0
 
-            avg_iter_s = sum(msg.recent_iters) / max(len(msg.recent_iters), 1)
-            avg_iter_time = pretty_ms(avg_iter_s * 1_000, format_sub_ms=True, unit_count=1)
-            print(f"{msg.count:,} at {avg_iter_time} per audit (best: {msg.best_rank})", file=sys.stderr)
+            if not cli_args.quiet:
+                avg_iter_s = sum(msg.recent_iters) / max(len(msg.recent_iters), 1)
+                avg_iter_time = pretty_ms(avg_iter_s * 1_000, format_sub_ms=True, unit_count=1)
+                print(f"{msg.count:,} at {avg_iter_time} per audit (best: {msg.best_rank})", file=sys.stderr)
 
         elif isinstance(msg, ResultMsg):
             if cli_args.tracemalloc_end:
                 snapshot = tracemalloc.take_snapshot()
                 display_top(snapshot)
-                return
+                return 0
 
-            print(result_str(msg, as_json=cli_args.json, as_raw=cli_args.raw, gpa_only=cli_args.gpa))
+            if not cli_args.quiet:
+                print(result_str(msg, as_json=cli_args.json, as_raw=cli_args.raw, gpa_only=cli_args.gpa))
+                return 0
 
         elif isinstance(msg, EstimateMsg):
-            print(f"estimated iterations: {msg.estimate:,}", file=sys.stderr)
+            if not cli_args.quiet:
+                print(f"estimated iterations: {msg.estimate:,}", file=sys.stderr)
 
         else:
-            logger.critical('unknown message %s', msg)
+            if not cli_args.quiet:
+                logger.critical('unknown message %s', msg)
+            return 1
+
+    return 0
 
 
 def result_str(msg: ResultMsg, *, as_json: bool = False, as_raw: bool = False, gpa_only: bool = False) -> str:
@@ -123,4 +139,4 @@ def display_top(snapshot, key_type='lineno', limit=10):
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/dp.py
+++ b/dp.py
@@ -1,3 +1,4 @@
+from typing import Any
 import argparse
 import logging
 import runpy
@@ -80,7 +81,6 @@ def main() -> int:
 
             if not cli_args.quiet:
                 print(result_str(msg, as_json=cli_args.json, as_raw=cli_args.raw, gpa_only=cli_args.gpa))
-                return 0
 
         elif isinstance(msg, EstimateMsg):
             if not cli_args.quiet:
@@ -109,7 +109,7 @@ def result_str(msg: ResultMsg, *, as_json: bool = False, as_raw: bool = False, g
     return "\n" + "".join(summarize(result=dict_result, transcript=msg.transcript, count=msg.count, elapsed=msg.elapsed, iterations=msg.iterations))
 
 
-def display_top(snapshot, key_type='lineno', limit=10):
+def display_top(snapshot: Any, key_type: str = 'lineno', limit: int = 10) -> None:
     import linecache
     from tracemalloc import Filter
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --doctest-modules

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 flake8==3.7.8
 pytest==5.0.1
 pytest-cov==2.7.1
-pytest-benchmark=3.2.2
+pytest-benchmark==3.2.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8==3.7.8
 pytest==5.0.1
 pytest-cov==2.7.1
+pytest-benchmark=3.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ attrs==19.1.0
 dataclasses==0.6
 psycopg2-binary==2.8.3
 python-dotenv==0.10.3
-pyyaml==5.1.1
+pyyaml==5.1.2
 sentry-sdk==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 attrs==19.1.0
-dataclasses==0.6
 psycopg2-binary==2.8.3
 python-dotenv==0.10.3
 pyyaml==5.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 attrs==19.1.0
 dataclasses==0.6
-fastnumbers==2.2.1
-natsort==6.0.0
 psycopg2-binary==2.8.3
 python-dotenv==0.10.3
 pyyaml==5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-coloredlogs==10.0
 attrs==19.1.0
 dataclasses==0.6
 fastnumbers==2.2.1

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -96,7 +96,7 @@ def test_insertion_on_count_rule__any(caplog):
 
     result = solutions[0].audit()
 
-    assert result.count == 1
+    assert result.result.count == 1
     assert result.ok() is True
     assert result.was_overridden() is False
     assert result.claims()[0].claim.clbid == course_b.clbid
@@ -130,7 +130,7 @@ def test_insertion_on_count_rule__all(caplog):
 
     result = solutions[0].audit()
 
-    assert result.count == 3
+    assert result.result.count == 3
     assert result.ok() is True
     assert result.was_overridden() is False
 
@@ -290,7 +290,7 @@ def test_override_on_count_rule_assertion_clause(caplog):
 
     result = solutions[0].audit()
 
-    assert result.audits()[0].was_overridden() is True
+    assert result.result.audits()[0].was_overridden() is True
     assert result.ok() is False
     assert result.was_overridden() is False
 
@@ -316,6 +316,6 @@ def test_override_on_query_rule_audit_clause(caplog):
 
     result = solutions[0].audit()
 
-    assert result.resolved_assertions[0].was_overridden() is True
+    assert result.result.resolved_assertions[0].was_overridden() is True
     assert result.ok() is True
     assert result.was_overridden() is False

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,7 +14,7 @@ def test_insertion_on_course_rule(caplog):
     area = AreaOfStudy.load(specification={"result": {"course": "DEPT 345"}}, c=c)
 
     exception = load_exception({
-        "action": "insert",
+        "type": "insert",
         "path": ["$", "*DEPT 345"],
         "clbid": "1",
     })
@@ -45,7 +45,7 @@ def test_insertion_on_query_rule(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "insert",
+        "type": "insert",
         "path": ["$", ".query"],
         "clbid": "0",
     })
@@ -75,7 +75,7 @@ def test_insertion_on_count_rule__any(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "insert",
+        "type": "insert",
         "path": ['$', '.count'],
         "clbid": "1",
     })
@@ -115,7 +115,7 @@ def test_insertion_on_count_rule__all(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "insert",
+        "type": "insert",
         "path": ['$', '.count'],
         "clbid": "2",
     })
@@ -149,7 +149,7 @@ def test_insertion_on_requirement_rule(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "insert",
+        "type": "insert",
         "path": ["$", r"%req"],
         "clbid": "2",
     })
@@ -175,7 +175,7 @@ def test_override_on_course_rule(caplog):
     area = AreaOfStudy.load(specification={"result": {"course": "DEPT 123"}}, c=c)
 
     exception = load_exception({
-        "action": "override",
+        "type": "override",
         "path": ["$", "*DEPT 123"],
         "status": "pass",
     })
@@ -200,7 +200,7 @@ def test_override_on_query_rule(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "override",
+        "type": "override",
         "path": ["$", ".query"],
         "status": "pass",
     })
@@ -226,7 +226,7 @@ def test_override_on_count_rule(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "override",
+        "type": "override",
         "path": ["$", ".count"],
         "status": "pass",
     })
@@ -251,7 +251,7 @@ def test_override_on_requirement_rule(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "override",
+        "type": "override",
         "path": ["$", r"%req"],
         "status": "pass",
     })
@@ -276,7 +276,7 @@ def test_override_on_count_rule_assertion_clause(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "override",
+        "type": "override",
         "path": ['$', '.count', '.audit', '[0]', '.assert'],
         "status": "pass",
     })
@@ -306,7 +306,7 @@ def test_override_on_query_rule_audit_clause(caplog):
     }, c=c)
 
     exception = load_exception({
-        "action": "override",
+        "type": "override",
         "path": ['$', '.query', '.assertions', '[0]', '.assert'],
         "status": "pass",
     })

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,7 @@
 from degreepath.data import course_from_str
 from degreepath.area import AreaOfStudy
 from degreepath.constants import Constants
-from degreepath.solution.course import CourseSolution
+from degreepath.result.course import CourseResult
 from degreepath.exception import load_exception
 import logging
 
@@ -85,11 +85,10 @@ def test_insertion_on_count_rule__any(caplog):
     transcript = [course_a, course_b]
 
     solutions = list(area.solutions(transcript=transcript, areas=[], exceptions=[exception]))
-    # for s in solutions:
-    #     print(s.solution.items)
+    print([s.solution for s in solutions])
 
     assert [
-        [x.course for x in s.solution.items if isinstance(x, CourseSolution)]
+        [x.course for x in s.solution.items if isinstance(x, CourseResult)]
         for s in solutions
     ] == [['OTHER 234']]
     assert len(solutions) == 1

--- a/tests/test_from.py
+++ b/tests/test_from.py
@@ -28,7 +28,7 @@ def test_from(caplog):
     ]
 
     s = next(area.solutions(transcript=transcript, areas=[], exceptions=[]))
-    a = s.audit()
+    a = s.audit().result
 
     assert len(a.successful_claims) == 1
 
@@ -55,7 +55,7 @@ def test_from_distinct(caplog):
     ]
 
     s = next(area.solutions(transcript=transcript, areas=[], exceptions=[]))
-    a = s.audit()
+    a = s.audit().result
 
     assert len(a.successful_claims) == 1
 

--- a/tests/test_independency.py
+++ b/tests/test_independency.py
@@ -1,0 +1,121 @@
+from degreepath.data import course_from_str
+from degreepath.area import AreaOfStudy
+from degreepath.constants import Constants
+from typing import Any
+import logging
+
+c = Constants(matriculation_year=2000)
+
+
+def test_overlaps(caplog: Any) -> None:
+    # caplog.set_level(logging.DEBUG)
+
+    area = AreaOfStudy.load(c=c, specification={
+        "result": {"all": [
+            {"requirement": "Core"},
+            {"requirement": "Electives"},
+        ]},
+        "requirements": {
+            "Core": {
+                "result": {"all": [
+                    {"course": "MUSIC 212"},
+                    {"course": "MUSIC 214"},
+                ]},
+            },
+            "Electives": {
+                "result": {
+                    "from": {"student": "courses"},
+                    "where": {
+                        "$and": [
+                            {"subject": {"$eq": "MUSIC"}},
+                            {"level": {"$eq": [300]}},
+                        ],
+                    },
+                    "all": [
+                        {"assert": {"count(courses)": {"$gte": 2}}},
+                    ],
+                },
+            },
+        },
+    })
+
+    transcript = [course_from_str(c) for c in [
+        "MUSIC 212", "MUSIC 214",
+        "MUSIC 301", "MUSIC 302",
+    ]]
+
+    solutions = list(area.solutions(transcript=transcript, areas=[], exceptions=[]))
+    assert len(solutions) == 1
+
+    result = solutions[0].audit()
+
+    assert result.ok() is False
+
+
+def x_test_overlaps(caplog: Any) -> None:
+    # caplog.set_level(logging.DEBUG)
+
+    area = AreaOfStudy.load(c=c, specification={
+        "result": {"all": [
+            {"requirement": "Core"},
+            {"requirement": "Electives"},
+            {"requirement": "Lessons"},
+        ]},
+        "requirements": {
+            "Core": {
+                "result": {"all": [
+                    {"course": "MUSIC 212"},
+                    {"course": "MUSIC 214"},
+                    {"course": "MUSIC 237"},
+                    {"course": "MUSIC 251"},
+                    {"course": "MUSIC 261"},
+                    {"course": "MUSIC 298"},
+                ]},
+            },
+            "Electives": {
+                "result": {
+                    "from": {"student": "courses"},
+                    "where": {
+                        "$and": [
+                            {"subject": {"$eq": "MUSIC"}},
+                            {"level": {"$in": [200, 300]}},
+                        ],
+                    },
+                    "all": [
+                        {"assert": {"count(courses)": {"$gte": 8}}},
+                        {
+                            "where": {"level": {"$eq": 300}},
+                            "assert": {"count(courses)": {"$gte": 2}},
+                        },
+                    ],
+                },
+            },
+            "Lessons": {
+                "result": {
+                    "from": {"student": "courses"},
+                    "where": {"subject": {"$eq": "MUSPF"}},
+                    "all": [
+                        {"assert": {"count(terms)": {"$gte": 6}}},
+                        {"assert": {"sum(credits)": {"$gte": 2.5}}},
+                        {
+                            "where": {"credits": {"$eq": 0.5}},
+                            "assert": {"count(terms)": {"$gte": 4}},
+                        },
+                    ],
+                },
+            },
+        },
+    })
+
+    transcript = [course_from_str(c) for c in [
+        "MUSIC 212", "MUSIC 214", "MUSIC 237", "MUSIC 251", "MUSIC 252", "MUSIC 298",
+        "MUSIC 222", "MUSIC 224", "MUSIC 247", "MUSIC 261", "MUSIC 262", "MUSIC 299", "MUSIC 301", "MUSIC 302",
+        "MUSPF 101", "MUSPF 102", "MUSPF 103", "MUSPF 104", "MUSPF 105", "MUSPF 106",
+    ]]
+
+    solutions = list(area.solutions(transcript=transcript, areas=[], exceptions=[]))
+    assert len(solutions) == 1
+
+    result = solutions[0].audit()
+
+    assert result.ok() is True

--- a/tests/test_independency.py
+++ b/tests/test_independency.py
@@ -1,6 +1,7 @@
 from degreepath.data import course_from_str
 from degreepath.area import AreaOfStudy
 from degreepath.constants import Constants
+from degreepath.context import RequirementContext
 from typing import Any
 import logging
 
@@ -9,6 +10,7 @@ c = Constants(matriculation_year=2000)
 
 def test_overlaps(caplog: Any) -> None:
     # caplog.set_level(logging.DEBUG)
+    global c
 
     area = AreaOfStudy.load(c=c, specification={
         "result": {"all": [
@@ -39,17 +41,17 @@ def test_overlaps(caplog: Any) -> None:
         },
     })
 
-    transcript = [course_from_str(c) for c in [
-        "MUSIC 212", "MUSIC 214",
-        "MUSIC 301", "MUSIC 302",
-    ]]
+    transcript = [course_from_str(c) for c in ["MUSIC 212", "MUSIC 214", "MUSIC 301", "MUSIC 302"]]
+    ctx = RequirementContext().with_transcript(transcript)
+
+    area.result.find_independent_children(items=area.result.items, ctx=ctx)
 
     solutions = list(area.solutions(transcript=transcript, areas=[], exceptions=[]))
     assert len(solutions) == 1
 
     result = solutions[0].audit()
 
-    assert result.ok() is False
+    assert result.ok() is True
 
 
 def x_test_overlaps(caplog: Any) -> None:

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -2,6 +2,7 @@ from degreepath.data import course_from_str
 from degreepath.area import AreaOfStudy
 from degreepath.constants import Constants
 from degreepath.solution.course import CourseSolution
+from degreepath.result.course import CourseResult
 import logging
 
 c = Constants(matriculation_year=2000)
@@ -27,10 +28,10 @@ def test_pruning_on_count_rule(caplog):
     solutions = list(area.solutions(transcript=transcript, areas=[], exceptions=[]))
 
     assert [
-        [x.course for x in s.solution.items if isinstance(x, CourseSolution)]
+        [x.course for x in s.solution.items if isinstance(x, CourseResult)]
         for s in solutions
-    ] == [['DEPT 123'], ['DEPT 234'], ['DEPT 123', 'DEPT 234']]
-    assert len(solutions) == 3
+    ] == [['DEPT 123', 'DEPT 234']]
+    assert len(solutions) == 1
 
     result = solutions[0].audit()
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -34,7 +34,7 @@ def test_pruning_on_count_rule(caplog):
 
     result = solutions[0].audit()
 
-    assert result.count == 1
+    assert result.result.count == 1
     assert result.ok() is True
     assert result.was_overridden() is False
     assert result.claims()[0].claim.clbid == course_a.clbid


### PR DESCRIPTION
This allows us to reduce the combinatorial explosion of possible solutions in most cases.

For example, many Music majors have an Electives and a Performance Studies requirement.

Requirement | Solution Count
--- | ---
Musicology | 2 solutions
Electives | 7735 solutions
Performance Studies | 255 solutions

… which comes out to 3,944,850 solutions.

Now, if we can prove that Performance Studies has no overlap with Electives or with Musicology, we can solve Performance Studies independently, and reduce our count to just `2 * 7735 = 15,470`.

This doesn't solve _everything_ (the B.M. Performance major allows overlap between Electives and Performance Studies, for instance), but it significantly helps out.

---

We also re-worked the sorting of the output data, so that the sort always matches the input sort.

---

We switched to `attrs` from `dataclasses`, to use the "cache_hash" function of attrs, which caches the hash of a class at creation time. Since we generate a bunch of hashes, this speeds things up.

---

We switched to "slotted classes", which… drastically reduced our memory usage.

row | before line | size | after line | size
--- | --- | --- | --- | ---
1 | `<string>` | 1,503,061.5 KiB | solution.requirement | 485,875.6 KiB
2 | base.bases | 336,373.6 KiB | solution.count | 448,512.9 KiB
3 | solution.count | 299,008.8 KiB | base.bases | 336,373.6 KiB
4 | solution.requirement | 299,000.6 KiB | rule.count | 37,378.5 KiB
5 | rule.count | 37,378.5 KiB | solution.query | 4,354.4 KiB
6 | rule.query | 3,667.1 KiB | rule.query | 3,667.1 KiB
7 | solution.query | 2,049.4 KiB | json.decoder | 105.5 KiB
8 | json.decoder | 104.6 KiB | solution.query | 98.8 KiB
9 | solution.query | 98.9 KiB | `<string>` | 36.8 KiB
10 | solution.query | 27.9 KiB | solution.query | 27.9 KiB
&nbsp; | 337 other | 398.4 KiB | 327 other | 405.0 KiB
&nbsp; | Total allocated size | 2,481,169.2 KiB | Total allocated size | 1,316,836.0 KiB



which, yes, cut our memory usage in half on that particular audit.


---

We finally added the "common major requirements", in Python (for now, at least).

---

We continued to rework the "rank" calculations, this time taking into account progress within the assertions on a query rule.