### PR TITLE
Fix limit sorting

### DIFF
--- a/degreepath/limit.py
+++ b/degreepath/limit.py
@@ -160,7 +160,13 @@ class LimitSet:
         logger.debug("limit: unmatched items: %s", unmatched_items)
 
         # we need to attach _a_ combo from each limit clause
-        clause_iterators = [limit.iterate(matchset) for limit, matchset in matched_items.items()]
+        clause_iterators = [
+            # be sure to sort the matchset, so that the output from
+            # the iterator is sorted the same way each time
+            limit.iterate(sorted(matchset))
+            for limit, matchset in matched_items.items()
+        ]
+
         emitted_solutions: Set[Tuple[T, ...]] = set()
         for results in itertools.product(*clause_iterators):
             these_items = tuple(sorted(item for group in results for item in group))

--- a/tests/test_global_limits.py
+++ b/tests/test_global_limits.py
@@ -1,7 +1,7 @@
 from degreepath.area import AreaOfStudy
 from degreepath.data import course_from_str
 from degreepath.constants import Constants
-import pytest
+import pytest  # type: ignore
 import io
 import yaml
 import logging


### PR DESCRIPTION
Closes #52 

The key was to sort the input into the limit iterator, because it takes a `matchset` as input, which is a set, and thus has no inherent ordering.

By sorting the input into the iterator, then, we ensure that the output comes out in a consistent order.