### PR TITLE
Exclude required courses from QueryRules

### DIFF
--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -99,6 +99,11 @@ class AreaOfStudy(Base):
         )
         assert result, TypeError(f'expected load_rule to process {specification["result"]}')
 
+        # Automatically exclude any "required" courses
+        if not emphasis_validity_check:
+            required_courses = result.get_required_courses(ctx=ctx)
+            result = result.exclude_required_courses(required_courses)
+
         limit = LimitSet.load(data=specification.get("limit", None), c=c)
 
         multicountable_rules: Dict[str, List[Tuple[str, ...]]] = {

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -108,6 +108,9 @@ class AreaOfStudy(Base):
             excluded_clbids = frozenset(c.clbid for c in required_courses)
             result = result.exclude_required_courses(required_courses)
 
+            for crs in required_courses:
+                logger.debug(f'excluding {crs.clbid} {crs.identity_}')
+
         limit = LimitSet.load(data=specification.get("limit", None), c=c)
 
         multicountable_rules: Dict[str, List[Tuple[str, ...]]] = {

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -196,6 +196,42 @@ class AreaOfStudy(Base):
 
         logger.debug("all solutions generated")
 
+    def estimate(
+        self, *,
+        transcript: Sequence[CourseInstance],
+        transcript_with_failed: Sequence[CourseInstance] = tuple(),
+        areas: Sequence[AreaPointer],
+        music_performances: Sequence[MusicPerformance] = tuple(),
+        music_attendances: Sequence[MusicAttendance] = tuple(),
+        music_proficiencies: MusicProficiencies = MusicProficiencies(),
+        exceptions: List[RuleException],
+    ) -> int:
+        forced_clbids = set(e.clbid for e in exceptions if isinstance(e, InsertionException) and e.forced is True)
+        forced_courses = {c.clbid: c for c in transcript if c.clbid in forced_clbids}
+
+        ctx = RequirementContext(
+            areas=tuple(areas),
+            music_performances=tuple(music_performances),
+            music_attendances=tuple(music_attendances),
+            music_proficiencies=music_proficiencies,
+            exceptions=exceptions,
+            multicountable=self.multicountable,
+        )
+
+        acc = 0
+
+        for limited_transcript in self.limit.limited_transcripts(courses=transcript):
+            ctx = ctx.with_transcript(
+                limited_transcript,
+                full=transcript,
+                forced=forced_courses,
+                including_failed=transcript_with_failed,
+            )
+
+            acc += self.result.estimate(ctx=ctx, depth=1)
+
+        return acc
+
 
 @attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class AreaSolution(AreaOfStudy):

--- a/degreepath/area.py
+++ b/degreepath/area.py
@@ -1,5 +1,5 @@
 import attr
-from typing import Dict, List, Set, Tuple, Optional, Sequence, Iterator, Iterable, Any, TYPE_CHECKING
+from typing import Dict, List, Set, FrozenSet, Tuple, Optional, Sequence, Iterator, Iterable, Any, TYPE_CHECKING
 import logging
 import decimal
 
@@ -37,6 +37,7 @@ class AreaOfStudy(Base):
     path: Tuple[str, ...]
 
     common_rules: Tuple[Rule, ...]
+    excluded_clbids: FrozenSet[str] = frozenset()
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -48,6 +49,7 @@ class AreaOfStudy(Base):
             "result": self.result.to_dict(),
             "gpa": str(self.gpa()),
             "limit": self.limit.to_dict(),
+            "excluded": sorted(clbid for clbid in self.excluded_clbids),
         }
 
     def type(self) -> str:
@@ -100,8 +102,10 @@ class AreaOfStudy(Base):
         assert result, TypeError(f'expected load_rule to process {specification["result"]}')
 
         # Automatically exclude any "required" courses
+        excluded_clbids: FrozenSet[str] = frozenset()
         if not emphasis_validity_check:
             required_courses = result.get_required_courses(ctx=ctx)
+            excluded_clbids = frozenset(c.clbid for c in required_courses)
             result = result.exclude_required_courses(required_courses)
 
         limit = LimitSet.load(data=specification.get("limit", None), c=c)
@@ -131,6 +135,7 @@ class AreaOfStudy(Base):
             limit=limit,
             path=('$',),
             code=this_code,
+            excluded_clbids=excluded_clbids,
             common_rules=tuple(prepare_common_rules(
                 other_areas=tuple(areas),
                 dept_code=dept,
@@ -209,6 +214,7 @@ class AreaSolution(AreaOfStudy):
             solution=solution,
             context=ctx,
             common_rules=area.common_rules,
+            excluded_clbids=area.excluded_clbids,
         )
 
     def audit(self) -> 'AreaResult':
@@ -293,6 +299,7 @@ class AreaResult(AreaOfStudy, Result):
             context=ctx,
             result=result,
             common_rules=area.common_rules,
+            excluded_clbids=area.excluded_clbids,
         )
 
     def gpa(self) -> decimal.Decimal:

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -119,6 +119,20 @@ def audit(
     iter_start = time.perf_counter()
     startup_time = 0.00
 
+    # estimate = area.estimate(
+    #     transcript=transcript,
+    #     areas=tuple(area_pointers),
+    #     music_performances=music_performances,
+    #     music_attendances=music_attendances,
+    #     music_proficiencies=music_proficiencies,
+    #     exceptions=list(exceptions),
+    #     transcript_with_failed=transcript_with_failed,
+    # )
+    # yield EstimateMsg(estimate=estimate)
+
+    # if args.estimate_only:
+    #     return
+
     potentials_for_all_clauses = find_potentials(area, constants)
 
     for sol in area.solutions(

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -79,7 +79,15 @@ class AreaFileNotFoundMsg:
     stnums: Sequence[str]
 
 
-Message = Union[ProgressMsg, NoAuditsCompletedMsg, ExceptionMsg, ResultMsg, AuditStartMsg, NoStudentsMsg, AreaFileNotFoundMsg]
+Message = Union[
+    ProgressMsg,
+    NoAuditsCompletedMsg,
+    ExceptionMsg,
+    ResultMsg,
+    AuditStartMsg,
+    NoStudentsMsg,
+    AreaFileNotFoundMsg,
+]
 
 
 def audit(

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -80,13 +80,13 @@ class AreaFileNotFoundMsg:
 
 
 Message = Union[
-    ProgressMsg,
-    NoAuditsCompletedMsg,
-    ExceptionMsg,
-    ResultMsg,
-    AuditStartMsg,
-    NoStudentsMsg,
     AreaFileNotFoundMsg,
+    AuditStartMsg,
+    ExceptionMsg,
+    NoAuditsCompletedMsg,
+    NoStudentsMsg,
+    ProgressMsg,
+    ResultMsg,
 ]
 
 

--- a/degreepath/audit.py
+++ b/degreepath/audit.py
@@ -20,6 +20,7 @@ class Arguments:
     area_specs: Sequence[Tuple[dict, str]] = tuple()
 
     transcript_only: bool = False
+    estimate_only: bool = False
     gpa_only: bool = False
 
     print_all: bool = False
@@ -66,6 +67,11 @@ class NoAuditsCompletedMsg:
 
 
 @attr.s(slots=True, kw_only=True, auto_attribs=True)
+class EstimateMsg:
+    estimate: int
+
+
+@attr.s(slots=True, kw_only=True, auto_attribs=True)
 class ProgressMsg:
     count: int
     recent_iters: List[float]
@@ -82,6 +88,7 @@ class AreaFileNotFoundMsg:
 Message = Union[
     AreaFileNotFoundMsg,
     AuditStartMsg,
+    EstimateMsg,
     ExceptionMsg,
     NoAuditsCompletedMsg,
     NoStudentsMsg,

--- a/degreepath/base/bases.py
+++ b/degreepath/base/bases.py
@@ -125,6 +125,14 @@ class Rule(Base):
         raise NotImplementedError(f'must define a get_requirement_names() method')
 
     @abc.abstractmethod
+    def get_required_courses(self, *, ctx: 'RequirementContext') -> Collection['CourseInstance']:
+        raise NotImplementedError(f'must define a get_required_courses() method')
+
+    @abc.abstractmethod
+    def exclude_required_courses(self, to_exclude: Collection['CourseInstance']) -> 'Rule':
+        raise NotImplementedError(f'must define an exclude_required_courses() method')
+
+    @abc.abstractmethod
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[Solution]:
         raise NotImplementedError(f'must define a solutions() method')
 

--- a/degreepath/base/bases.py
+++ b/degreepath/base/bases.py
@@ -137,6 +137,10 @@ class Rule(Base):
         raise NotImplementedError(f'must define a solutions() method')
 
     @abc.abstractmethod
+    def estimate(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> int:
+        raise NotImplementedError(f'must define an estimate() method')
+
+    @abc.abstractmethod
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
         raise NotImplementedError(f'must define a has_potential() method')
 

--- a/degreepath/limit.py
+++ b/degreepath/limit.py
@@ -7,6 +7,7 @@ import logging
 from .clause import Clause, str_clause
 from .load_clause import load_clause
 from .constants import Constants
+from .ncr import ncr
 
 from .data.clausable import Clausable
 
@@ -60,6 +61,14 @@ class Limit:
             for combo in itertools.combinations(courses, n):
                 logger.debug("limit/loop(%s..<%s)/combo: n=%s combo=%s", 0, self.at_most + 1, n, combo)
                 yield combo
+
+    def estimate(self, courses: Sequence[T]) -> int:
+        acc = 0
+
+        for n in range(0, self.at_most + 1):
+            acc += ncr(len(courses), n)
+
+        return acc
 
 
 @attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
@@ -176,3 +185,7 @@ class LimitSet:
 
             logger.debug("limit/combos: %s", this_combo)
             yield tuple(this_combo)
+
+    def estimate(self, courses: Sequence[T]) -> int:
+        # TODO: optimize this so that it doesn't need to actually build the results
+        return sum(1 for _ in self.limited_transcripts(courses))

--- a/degreepath/rule/assertion.py
+++ b/degreepath/rule/assertion.py
@@ -11,7 +11,7 @@ from ..base.assertion import BaseAssertionRule
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import RequirementContext
-    from ..data import Clausable  # noqa: F401
+    from ..data import Clausable, CourseInstance  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,12 @@ class AssertionRule(Rule, BaseAssertionRule):
 
     def get_requirement_names(self) -> List[str]:
         return []
+
+    def get_required_courses(self, *, ctx: 'RequirementContext') -> Collection['CourseInstance']:
+        return tuple()
+
+    def exclude_required_courses(self, to_exclude: Collection['CourseInstance']) -> 'AssertionRule':
+        return self
 
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[Solution]:
         raise Exception('this method should not be called')
@@ -113,6 +119,12 @@ class ConditionalAssertionRule(Rule):
 
     def get_requirement_names(self) -> List[str]:
         return self.when_yes.get_requirement_names()
+
+    def get_required_courses(self, *, ctx: 'RequirementContext') -> Collection['CourseInstance']:
+        return self.when_yes.get_required_courses(ctx=ctx)
+
+    def exclude_required_courses(self, to_exclude: Collection['CourseInstance']) -> 'ConditionalAssertionRule':
+        return self
 
     def resolve(self, input: Sequence['Clausable']) -> Optional[AssertionRule]:
         if self.condition.where is not None:

--- a/degreepath/rule/assertion.py
+++ b/degreepath/rule/assertion.py
@@ -61,7 +61,7 @@ class AssertionRule(Rule, BaseAssertionRule):
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[Solution]:
         raise Exception('this method should not be called')
 
-    def estimate(self, *, ctx: 'RequirementContext') -> int:
+    def estimate(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> int:
         raise Exception('this method should not be called')
 
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
@@ -114,7 +114,7 @@ class ConditionalAssertionRule(Rule):
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[Solution]:
         return self.when_yes.solutions(ctx=ctx, depth=depth)
 
-    def estimate(self, *, ctx: 'RequirementContext') -> int:
+    def estimate(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> int:
         return self.when_yes.estimate(ctx=ctx)
 
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:

--- a/degreepath/rule/assertion.py
+++ b/degreepath/rule/assertion.py
@@ -61,6 +61,9 @@ class AssertionRule(Rule, BaseAssertionRule):
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[Solution]:
         raise Exception('this method should not be called')
 
+    def estimate(self, *, ctx: 'RequirementContext') -> int:
+        raise Exception('this method should not be called')
+
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
         raise Exception('this method should not be called')
 
@@ -110,6 +113,9 @@ class ConditionalAssertionRule(Rule):
 
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[Solution]:
         return self.when_yes.solutions(ctx=ctx, depth=depth)
+
+    def estimate(self, *, ctx: 'RequirementContext') -> int:
+        return self.when_yes.estimate(ctx=ctx)
 
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
         return self.when_yes.has_potential(ctx=ctx)

--- a/degreepath/rule/count.py
+++ b/degreepath/rule/count.py
@@ -62,6 +62,8 @@ class CountRule(Rule, BaseCountRule):
         else:
             items = data["of"]
 
+        items = list(items)
+
         children_with_emphases = {**children}
         for emph in emphases:
             emphasis_key = f"Emphasis: {emph['name']}"

--- a/degreepath/rule/course.py
+++ b/degreepath/rule/course.py
@@ -73,6 +73,17 @@ class CourseRule(Rule, BaseCourseRule):
     def get_requirement_names(self) -> List[str]:
         return []
 
+    def get_required_courses(self, *, ctx: 'RequirementContext') -> Collection['CourseInstance']:
+        matches = self.all_matches(ctx=ctx)
+
+        if len(matches) == 1:
+            return tuple(matches)
+
+        return tuple()
+
+    def exclude_required_courses(self, to_exclude: Collection['CourseInstance']) -> 'CourseRule':
+        return self
+
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[CourseSolution]:
         if self.waived or ctx.get_waive_exception(self.path):
             logger.debug("forced override on %s", self.path)

--- a/degreepath/rule/course.py
+++ b/degreepath/rule/course.py
@@ -94,7 +94,7 @@ class CourseRule(Rule, BaseCourseRule):
 
         yield CourseSolution.from_rule(rule=self)
 
-    def estimate(self, *, ctx: 'RequirementContext') -> int:
+    def estimate(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> int:
         return 1
 
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:

--- a/degreepath/rule/course.py
+++ b/degreepath/rule/course.py
@@ -94,6 +94,9 @@ class CourseRule(Rule, BaseCourseRule):
 
         yield CourseSolution.from_rule(rule=self)
 
+    def estimate(self, *, ctx: 'RequirementContext') -> int:
+        return 1
+
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
         if self._has_potential(ctx=ctx):
             logger.debug('%s has potential: yes', self.path)

--- a/degreepath/rule/proficiency.py
+++ b/degreepath/rule/proficiency.py
@@ -65,7 +65,7 @@ class ProficiencyRule(Rule, BaseProficiencyRule):
 
         yield ProficiencySolution.from_rule(rule=self, course_solution=course_solution)
 
-    def estimate(self, *, ctx: 'RequirementContext') -> int:
+    def estimate(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> int:
         return 1
 
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:

--- a/degreepath/rule/proficiency.py
+++ b/degreepath/rule/proficiency.py
@@ -65,6 +65,9 @@ class ProficiencyRule(Rule, BaseProficiencyRule):
 
         yield ProficiencySolution.from_rule(rule=self, course_solution=course_solution)
 
+    def estimate(self, *, ctx: 'RequirementContext') -> int:
+        return 1
+
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
         return True
 

--- a/degreepath/rule/proficiency.py
+++ b/degreepath/rule/proficiency.py
@@ -9,7 +9,7 @@ from .course import CourseRule
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import RequirementContext
-    from ..data import Clausable  # noqa: F401
+    from ..data import Clausable, CourseInstance  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +45,14 @@ class ProficiencyRule(Rule, BaseProficiencyRule):
 
     def get_requirement_names(self) -> List[str]:
         return []
+
+    def get_required_courses(self, *, ctx: 'RequirementContext') -> Collection['CourseInstance']:
+        if self.course:
+            return self.course.get_required_courses(ctx=ctx)
+        return tuple()
+
+    def exclude_required_courses(self, to_exclude: Collection['CourseInstance']) -> 'ProficiencyRule':
+        return self
 
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[ProficiencySolution]:
         if ctx.get_waive_exception(self.path):

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -94,7 +94,8 @@ class QueryRule(Rule, BaseQueryRule):
 
     def get_data(self, *, ctx: 'RequirementContext') -> Sequence[Clausable]:
         if self.source is QuerySource.Courses:
-            return ctx.transcript()
+            all_courses = ctx.transcript()
+            return [c for c in all_courses if c.clbid not in self.excluded_clbids]
 
         elif self.source is QuerySource.Areas:
             return list(ctx.areas)

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -164,7 +164,7 @@ class QueryRule(Rule, BaseQueryRule):
             logger.debug("%s did not yield anything; yielding empty collection", self.path)
             yield QuerySolution.from_rule(rule=self, output=tuple())
 
-    def estimate(self, *, ctx: 'RequirementContext') -> int:
+    def estimate(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> int:
         if ctx.get_waive_exception(self.path):
             return 1
 

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -122,13 +122,14 @@ class QueryRule(Rule, BaseQueryRule):
 
         inserted_clbids: Tuple[str, ...] = tuple()
         force_inserted_clbids: Tuple[str, ...] = tuple()
-        for insert in ctx.get_insert_exceptions(self.path):
-            inserted_clbids = (*inserted_clbids, insert.clbid)
-            if insert.forced:
-                force_inserted_clbids = (*force_inserted_clbids, insert.clbid)
+        if self.source is QuerySource.Courses:
+            for insert in ctx.get_insert_exceptions(self.path):
+                inserted_clbids = (*inserted_clbids, insert.clbid)
+                if insert.forced:
+                    force_inserted_clbids = (*force_inserted_clbids, insert.clbid)
 
-            matched_course = ctx.forced_course_by_clbid(insert.clbid, path=self.path)
-            data.append(matched_course)
+                matched_course = ctx.forced_course_by_clbid(insert.clbid, path=self.path)
+                data.append(matched_course)
 
         return data, inserted_clbids, force_inserted_clbids
 

--- a/degreepath/rule/query.py
+++ b/degreepath/rule/query.py
@@ -1,5 +1,5 @@
 import attr
-from typing import Dict, List, Optional, Sequence, Iterator, Callable, Collection, Union, Tuple, cast, TYPE_CHECKING
+from typing import Dict, List, Optional, Sequence, Iterator, Callable, Collection, FrozenSet, Union, Tuple, cast, TYPE_CHECKING
 import itertools
 import logging
 import decimal
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 @attr.s(cache_hash=True, slots=True, kw_only=True, frozen=True, auto_attribs=True)
 class QueryRule(Rule, BaseQueryRule):
     load_potentials: bool
+    excluded_clbids: FrozenSet[str] = frozenset()
 
     @staticmethod
     def can_load(data: Dict) -> bool:
@@ -75,6 +76,11 @@ class QueryRule(Rule, BaseQueryRule):
             force_inserted=tuple(),
         )
 
+    def exclude_required_courses(self, to_exclude: Collection['CourseInstance']) -> 'QueryRule':
+        clbids = frozenset(c.clbid for c in to_exclude)
+        logger.debug(f'{self.path} excluding required courses: {sorted(c for c in clbids)}')
+        return attr.evolve(self, excluded_clbids=clbids)
+
     def validate(self, *, ctx: 'RequirementContext') -> None:
         if self.assertions:
             for a in self.assertions:
@@ -82,6 +88,9 @@ class QueryRule(Rule, BaseQueryRule):
 
     def get_requirement_names(self) -> List[str]:
         return []
+
+    def get_required_courses(self, *, ctx: 'RequirementContext') -> Collection['CourseInstance']:
+        return tuple()
 
     def get_data(self, *, ctx: 'RequirementContext') -> Sequence[Clausable]:
         if self.source is QuerySource.Courses:

--- a/degreepath/rule/requirement.py
+++ b/degreepath/rule/requirement.py
@@ -12,7 +12,7 @@ from ..solve import find_best_solution
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import RequirementContext
-    from ..data import Clausable  # noqa: F401
+    from ..data import Clausable, CourseInstance  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +117,18 @@ class RequirementRule(Rule, BaseRequirementRule):
 
     def get_requirement_names(self) -> List[str]:
         return [self.name]
+
+    def get_required_courses(self, *, ctx: 'RequirementContext') -> Collection['CourseInstance']:
+        if self.result:
+            return self.result.get_required_courses(ctx=ctx)
+        return tuple()
+
+    def exclude_required_courses(self, to_exclude: Collection['CourseInstance']) -> 'RequirementRule':
+        if not self.result:
+            return self
+
+        result = self.result.exclude_required_courses(to_exclude)
+        return attr.evolve(self, result=result)
 
     def solutions(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> Iterator[RequirementSolution]:
         if ctx.get_waive_exception(self.path):

--- a/degreepath/rule/requirement.py
+++ b/degreepath/rule/requirement.py
@@ -149,7 +149,7 @@ class RequirementRule(Rule, BaseRequirementRule):
         for solution in self.result.solutions(ctx=ctx):
             yield RequirementSolution.from_rule(rule=self, solution=solution)
 
-    def estimate(self, *, ctx: 'RequirementContext') -> int:
+    def estimate(self, *, ctx: 'RequirementContext', depth: Optional[int] = None) -> int:
         if ctx.get_waive_exception(self.path):
             return 1
 

--- a/degreepath/rule/requirement.py
+++ b/degreepath/rule/requirement.py
@@ -149,6 +149,15 @@ class RequirementRule(Rule, BaseRequirementRule):
         for solution in self.result.solutions(ctx=ctx):
             yield RequirementSolution.from_rule(rule=self, solution=solution)
 
+    def estimate(self, *, ctx: 'RequirementContext') -> int:
+        if ctx.get_waive_exception(self.path):
+            return 1
+
+        if not self.result:
+            return 1
+
+        return self.result.estimate(ctx=ctx)
+
     def has_potential(self, *, ctx: 'RequirementContext') -> bool:
         if self._has_potential(ctx=ctx):
             logger.debug('%s has potential: yes', self.path)

--- a/dp.py
+++ b/dp.py
@@ -13,7 +13,7 @@ from degreepath.main import run
 from degreepath.ms import pretty_ms
 from degreepath.stringify import summarize
 from degreepath.stringify_csv import to_csv
-from degreepath.audit import NoStudentsMsg, ResultMsg, AuditStartMsg, ExceptionMsg, NoAuditsCompletedMsg, ProgressMsg, Arguments, AreaFileNotFoundMsg
+from degreepath.audit import EstimateMsg, NoStudentsMsg, ResultMsg, AuditStartMsg, ExceptionMsg, NoAuditsCompletedMsg, ProgressMsg, Arguments, AreaFileNotFoundMsg
 
 dotenv.load_dotenv(verbose=False)
 
@@ -63,6 +63,7 @@ def main() -> int:  # noqa: C901
         stop_after=cli_args.stop_after,
         student_files=cli_args.student_files,
         transcript_only=cli_args.transcript,
+        estimate_only=cli_args.estimate,
     )
 
     if has_tracemalloc:
@@ -93,6 +94,10 @@ def main() -> int:  # noqa: C901
 
         elif isinstance(msg, AreaFileNotFoundMsg):
             pass
+
+        elif isinstance(msg, EstimateMsg):
+            if not cli_args.quiet:
+                print(f"{msg.estimate:,} estimated solution{'s' if msg.estimate != 1 else ''}", file=sys.stderr)
 
         elif isinstance(msg, ProgressMsg):
             if (cli_args.tracemalloc_init and first_progress_message) or cli_args.tracemalloc_each:


### PR DESCRIPTION
… in order to reduce (sometimes drastically) the number of possible solutions for a `QueryRule`.

A "required" course is one that must always be taken. To show that a course is required, it - and all of its ancestors – must be within `all:`-based count rules.

Any time there is a possibility that a course might not be absolutely required, we don't include it as a required course.

Once we have our set of required clbids, go through each nested rule. When you find a Query, add the clbids to the new “excluded_clbids” property on the query.

Now, when a query calls get_data, the first thing it does is remove all courses with clbids in the excluded set, before it runs the normal query, so that we automatically remove the courses that can’t possibly be used there.

---

(include speed-up statistics here)

[I can say that I've seen some audits as drastic as going from 218million+ to ~300,000 solutions, which is much nicer.]