### PR TITLE
Remove markdown dependency

### DIFF
--- a/dp/autop/__init__.py
+++ b/dp/autop/__init__.py
@@ -1,0 +1,3 @@
+# noqa: F401
+
+from .autop import autop

--- a/dp/autop/__init__.py
+++ b/dp/autop/__init__.py
@@ -1,3 +1,3 @@
-# noqa: F401
+# flake8: noqa F401
 
 from .autop import autop

--- a/dp/autop/autop.py
+++ b/dp/autop/autop.py
@@ -1,0 +1,20 @@
+from textwrap import dedent
+
+
+def autop(data: str) -> str:
+    data = dedent(data)
+
+    chunks = (chunk for chunk in data.split('\n\n'))
+
+    chunks = (para.strip() for para in chunks)
+
+    chunks = (' '.join(para.split('\n')) for para in chunks)
+
+    return ''.join(wrap_untagged(chunk) for chunk in chunks)
+
+
+def wrap_untagged(chunk: str) -> str:
+    if chunk.startswith('<'):
+        return chunk
+    else:
+        return f"<p>{chunk}</p>"

--- a/dp/rule/requirement.py
+++ b/dp/rule/requirement.py
@@ -10,6 +10,8 @@ from ..rule.query import QueryRule
 from ..solve import find_best_solution
 from ..status import PassingStatuses
 
+from ..autop import autop
+
 if TYPE_CHECKING:  # pragma: no cover
     from ..context import RequirementContext
     from ..data import Clausable, CourseInstance  # noqa: F401
@@ -87,7 +89,7 @@ class RequirementRule(Rule, BaseRequirementRule):
 
         message = data.get("message", None)
         if message:
-            message = markdown2.markdown(message)
+            message = autop(message)
 
         return RequirementRule(
             name=name,

--- a/dp/rule/requirement.py
+++ b/dp/rule/requirement.py
@@ -1,7 +1,6 @@
 from typing import Any, Mapping, Optional, List, Iterator, Collection, TYPE_CHECKING
 import logging
 import attr
-import markdown2  # type: ignore
 
 from ..base import Rule, BaseRequirementRule
 from ..constants import Constants

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 attrs==19.3.0
-markdown2==2.3.8
 openpyxl==3.0.3
 pyyaml==5.3
 tqdm==4.43.0


### PR DESCRIPTION
closes #69 

I don't want to write `<p>` tags, but I use the rest of markdown so rarely that I'd rather not pull in a whole library for parsing it.

I'm OK with writing HTML for `<ul>`, `<em>`, etc.