### PR TITLE
update the CI workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,10 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version:
-          - 3.6
-          - 3.7
-          - 3.8
+        python-version: ['3.8']
 
     steps:
       - uses: actions/checkout@v1
@@ -47,14 +44,41 @@ jobs:
         run: |
           pytest tests/ dp/
 
-  pypy-test:
+  cpython-check-runs:
     runs-on: ubuntu-latest
 
     strategy:
       max-parallel: 4
       matrix:
         python-version:
-          - pypy3
+          - '3.6'
+          - '3.7'
+          - '3.8'
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Test that the thing runs
+        run: |
+          python3 -m dp --help
+          python3 -m dp.bin.validate --help
+          python3 -m dp.bin.discover --help
+
+  pypy-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [pypy3]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Run smoke tests on Python 3.6-3.8, and full unit tests only on 3.8, because the auditor normally runs under 3.8, but a few of the helper scripts need to run in a 3.6 environment.

This should allow us to rework the `importlib` dependency, which is only needed below 3.8, because it's not needed in the 3.6 scripts.